### PR TITLE
Moving the return outside the if, so that the creation of a Transport…

### DIFF
--- a/pvAccessJava/src/org/epics/pvaccess/client/impl/remote/ChannelImpl.java
+++ b/pvAccessJava/src/org/epics/pvaccess/client/impl/remote/ChannelImpl.java
@@ -446,8 +446,8 @@ public class ChannelImpl implements Channel, SearchInstance, TransportClient, Tr
 			{
 				requester.message("More than one channel with name '" + name +
 							 "' detected, connected to: " + transport.getRemoteAddress() + ", ignored: " + serverAddress, MessageType.warning);
-				return;
 			}
+			return;
 		}
 		
 		transport = context.getTransport(this, serverAddress, minorRevision, priority);


### PR DESCRIPTION
… is always skipped if it already exists.
See #73 