### PR TITLE
Issue_96 Write of VDoubleArray fails

### DIFF
--- a/gpclient/gpclient-ca/src/main/java/org/epics/gpclient/datasource/ca/CAChannelHandler.java
+++ b/gpclient/gpclient-ca/src/main/java/org/epics/gpclient/datasource/ca/CAChannelHandler.java
@@ -30,12 +30,14 @@ import org.epics.gpclient.WriteCollector.WriteRequest;
 import org.epics.gpclient.datasource.MultiplexedChannelHandler;
 import org.epics.gpclient.datasource.ca.types.CATypeAdapter;
 import org.epics.util.array.ListNumber;
+import org.epics.util.array.UnsafeUnwrapper;
 import org.epics.vtype.VByte;
 import org.epics.vtype.VDouble;
 import org.epics.vtype.VEnum;
 import org.epics.vtype.VFloat;
 import org.epics.vtype.VInt;
 import org.epics.vtype.VLong;
+import org.epics.vtype.VNumberArray;
 import org.epics.vtype.VShort;
 
 import java.math.BigInteger;
@@ -280,15 +282,17 @@ public class CAChannelHandler extends MultiplexedChannelHandler<CAConnectionPayl
 
     @Override
     protected void write(Object newValue) {
+        if(newValue instanceof VNumberArray){
+            newValue = ((VNumberArray) newValue).getData();
+        }
         // If it's a ListNumber, extract the array
         if (newValue instanceof ListNumber) {
             ListNumber data = (ListNumber) newValue;
-            Object wrappedArray = wrappedArray(data);
+            UnsafeUnwrapper.Array<?> wrappedArray = wrappedArray(data);
             if (wrappedArray == null) {
-                newValue = wrappedDoubleArray(data);
-            } else {
-                newValue = wrappedArray;
+                wrappedArray = wrappedDoubleArray(data);
             }
+            newValue = wrappedArray.array;
         }
         try {
             if (newValue instanceof Double[]) {

--- a/gpclient/gpclient-ca/src/test/java/org/epics/gpclient/datasource/ca/CAChannelHandlerTest.java
+++ b/gpclient/gpclient-ca/src/test/java/org/epics/gpclient/datasource/ca/CAChannelHandlerTest.java
@@ -5,6 +5,7 @@ import gov.aps.jca.Context;
 import gov.aps.jca.dbr.DBRType;
 import gov.aps.jca.event.ConnectionListener;
 import org.epics.util.array.ArrayDouble;
+import org.epics.util.array.ArrayInteger;
 import org.epics.util.array.ListNumber;
 import org.epics.vtype.Alarm;
 import org.epics.vtype.Display;
@@ -12,9 +13,11 @@ import org.epics.vtype.EnumDisplay;
 import org.epics.vtype.Time;
 import org.epics.vtype.VByte;
 import org.epics.vtype.VDouble;
+import org.epics.vtype.VDoubleArray;
 import org.epics.vtype.VEnum;
 import org.epics.vtype.VFloat;
 import org.epics.vtype.VInt;
+import org.epics.vtype.VIntArray;
 import org.epics.vtype.VLong;
 import org.epics.vtype.VShort;
 import org.junit.Before;
@@ -45,19 +48,26 @@ public class CAChannelHandlerTest {
         caChannelHandler.connect();
     }
 
-    /**
-     * This is deliberately disabled. It should be fine, but the logic
-     * handling {@link ListNumber}s is broken as type information is lost
-     * in the transformations happening in other classes.
-     * @throws Exception
-     */
     @Test
-    @Ignore
     public void testWriteListNumberDouble() throws Exception{
 
         ListNumber doubles = ArrayDouble.of(Double.valueOf(1.1d), Double.valueOf(2.2d));
         caChannelHandler.write(doubles);
         verify(channel).put(new double[]{1.1d, 2.2d});
+    }
+
+    @Test
+    public void testWriteVDoubleArray() throws Exception{
+        VDoubleArray vDoubleArray = VDoubleArray.of(ArrayDouble.of(1.1d, 2.2d), Alarm.none(), Time.now(), Display.none());
+        caChannelHandler.write(vDoubleArray);
+        verify(channel).put(new double[]{1.1d, 2.2d});
+    }
+
+    @Test
+    public void testWriteVIntArray() throws Exception{
+        VIntArray vIntArray = VIntArray.of(ArrayInteger.of(1, 2), Alarm.none(), Time.now(), Display.none());
+        caChannelHandler.write(vIntArray);
+        verify(channel).put(new int[]{1, 2});
     }
 
     @Test

--- a/gpclient/gpclient-pva/src/main/java/org/epics/gpclient/datasource/pva/PVAChannelHandler.java
+++ b/gpclient/gpclient-pva/src/main/java/org/epics/gpclient/datasource/pva/PVAChannelHandler.java
@@ -47,6 +47,7 @@ import org.epics.gpclient.datasource.MultiplexedChannelHandler;
 import org.epics.util.array.CollectionNumbers;
 import org.epics.util.array.ListNumber;
 import org.epics.util.array.UnsafeUnwrapper;
+import org.epics.vtype.VNumberArray;
 
 /**
  * 
@@ -533,11 +534,14 @@ class PVAChannelHandler extends
         }
         else if (channelPutValueField instanceof PVScalarArray)
         {
+        	if(newValue instanceof VNumberArray){
+        		newValue = ((VNumberArray) newValue).getData();
+			}
             // if it's a ListNumber, extract the array
             if (newValue instanceof ListNumber) {
                 ListNumber data = (ListNumber) newValue;
                 // FIXME: Optimize!!! You should get the array type of whatever it is and write the exact boundaries
-                Object wrappedArray = UnsafeUnwrapper.readSafeDoubleArray(data).array;
+                newValue = UnsafeUnwrapper.readSafeDoubleArray(data).array;
             }
             else if (!newValue.getClass().isArray())
             {


### PR DESCRIPTION
Updated both CAChannelHandler and PVAChannelHandler to support wrote of VNumberArray types. This also fixed a bug where ListNumber type were not written.