### PR TITLE
SPI to OSGI container compatibility.

### DIFF
--- a/gpclient/gpclient-ca/pom.xml
+++ b/gpclient/gpclient-ca/pom.xml
@@ -49,6 +49,15 @@
           </execution>
         </executions>
       </plugin>
+        <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <configuration>
+                <instructions>
+                    <SPI-Provider>*</SPI-Provider>
+                </instructions>
+            </configuration>
+        </plugin>          
     </plugins>
   </build>
 </project>

--- a/gpclient/gpclient-core/pom.xml
+++ b/gpclient/gpclient-core/pom.xml
@@ -9,6 +9,19 @@
     <artifactId>gpclient-core</artifactId>
     <name>org.epics.gpclient</name>
     <description>The main library for the generic purpose JAVA EPICS client.</description>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                    <SPI-Consumer>*</SPI-Consumer>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>       
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/gpclient/gpclient-loc/pom.xml
+++ b/gpclient/gpclient-loc/pom.xml
@@ -36,6 +36,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <SPI-Provider>*</SPI-Provider>
+                    </instructions>
+                </configuration>
+            </plugin>                
         </plugins>
     </build>
 </project>

--- a/gpclient/gpclient-pva/pom.xml
+++ b/gpclient/gpclient-pva/pom.xml
@@ -40,6 +40,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <SPI-Provider>*</SPI-Provider>
+                    </instructions>
+                </configuration>
+            </plugin>                
         </plugins>
     </build>
 </project>

--- a/gpclient/gpclient-sim/pom.xml
+++ b/gpclient/gpclient-sim/pom.xml
@@ -41,6 +41,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <SPI-Provider>*</SPI-Provider>
+                    </instructions>
+                </configuration>
+            </plugin>            
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Hi,

This modification allows the use of the **gpclient** libraries in an OSGi container (Karaf for example). No modification is made to the base code, only the insertion of a line in the header of the generated bundle to export and import the SPI services in the OSGi environment.

Thanks,
