### PR TITLE
Use JsonBuilderFactor to create JsonObjectBuilder

### DIFF
--- a/epics-vtype/vtype-json/src/main/java/org/epics/vtype/json/JsonVTypeBuilder.java
+++ b/epics-vtype/vtype-json/src/main/java/org/epics/vtype/json/JsonVTypeBuilder.java
@@ -8,6 +8,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Collections;
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
@@ -31,8 +32,9 @@ import org.epics.vtype.VType;
  * @author carcassi
  */
 class JsonVTypeBuilder implements JsonObjectBuilder {
-    
-    private final JsonObjectBuilder builder = Json.createObjectBuilder();
+
+    private static final JsonBuilderFactory factory = Json.createBuilderFactory(Collections.emptyMap());
+    private final JsonObjectBuilder builder = factory.createObjectBuilder();
 
     @Override
     public JsonVTypeBuilder add(String string, JsonValue jv) {

--- a/epics-vtype/vtype-json/src/main/java/org/epics/vtype/json/JsonVTypeBuilder.java
+++ b/epics-vtype/vtype-json/src/main/java/org/epics/vtype/json/JsonVTypeBuilder.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonValue;
 import static org.epics.vtype.json.JsonArrays.*;


### PR DESCRIPTION
@georgweiss Json.createObjectBuilder() method has overhead to create an object.
Using createObjectBuilder() method in JsonBuilderFactor eliminates the overhead.

Using Phoebus Save&Restore application, I tested serializing 24k Java objects.

<img width="361" alt="2020-09-11_10-11-55" src="https://user-images.githubusercontent.com/5515875/92938734-f67dfb80-f41a-11ea-9181-9e9c618a1c3b.png">

Mean processing time reduced from 48.4s to 12s, more than 4 times faster. 