### PR TITLE
Gson de/serializer for vtype

### DIFF
--- a/epics-vtype/pom.xml
+++ b/epics-vtype/pom.xml
@@ -17,6 +17,7 @@
     <modules>
         <module>vtype</module>
         <module>vtype-json</module>
+        <module>vtype-gson</module>
     </modules>
     <build>
         <!-- Reset to standard source directories -->

--- a/epics-vtype/vtype-gson/pom.xml
+++ b/epics-vtype/vtype-gson/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion><build><plugins><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><configuration><source>8</source><target>8</target></configuration></plugin></plugins></build>
+    <parent>
+        <groupId>org.epics</groupId>
+        <artifactId>epics-vtype-all</artifactId>
+        <version>1.0.4-SNAPSHOT</version>
+    </parent>
+    <artifactId>vtype-gson</artifactId>
+    <name>org.epics.vtype.gson</name>
+    <description>Google GSON de/serializer for value types.</description>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>vtype</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.6</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.1</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/CustomGson.java
+++ b/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/CustomGson.java
@@ -31,7 +31,7 @@ import java.util.Date;
 /**
  * Custom Gson object creator having some TypeAdapters and options
  *
- * @author <a href='mailto:changj@frib.msu.edu>Genie Jhang</a>
+ * @author <a href="mailto:changj@frib.msu.edu">Genie Jhang</a>
  */
 
 public class CustomGson {

--- a/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/CustomGson.java
+++ b/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/CustomGson.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2020 Facility for Rare Isotope Beams
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact Information: Facility for Rare Isotope Beam,
+ *                      Michigan State University,
+ *                      East Lansing, MI 48824-1321
+ *                      http://frib.msu.edu
+ */
+package org.epics.vtype.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.epics.vtype.VType;
+
+import java.text.DecimalFormat;
+import java.util.Date;
+
+/**
+ * Custom Gson object creator having some TypeAdapters and options
+ *
+ * @author <a href='mailto:changj@frib.msu.edu>Genie Jhang</a>
+ */
+
+public class CustomGson {
+    public static Gson getGson() {
+        return new GsonBuilder()
+                .registerTypeAdapter(VType.class, new GsonVTypeHandler())
+                .registerTypeAdapter(Date.class, new GsonDateHandler())
+                .registerTypeAdapter(DecimalFormat.class, new GsonDecimalFormatHandler())
+                .serializeNulls()
+                .serializeSpecialFloatingPointValues()
+                .create();
+    }
+}

--- a/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonArrays.java
+++ b/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonArrays.java
@@ -1,0 +1,331 @@
+/**
+ * Copyright information and license terms for this software can be
+ * found in the file LICENSE.TXT included with the distribution.
+ */
+package org.epics.vtype.gson;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import org.epics.util.array.ArrayByte;
+import org.epics.util.array.ArrayDouble;
+import org.epics.util.array.ArrayFloat;
+import org.epics.util.array.ArrayInteger;
+import org.epics.util.array.ArrayLong;
+import org.epics.util.array.ArrayShort;
+import org.epics.util.array.ArrayUByte;
+import org.epics.util.array.ArrayUInteger;
+import org.epics.util.array.ArrayULong;
+import org.epics.util.array.ArrayUShort;
+import org.epics.util.array.ListByte;
+import org.epics.util.array.ListDouble;
+import org.epics.util.array.ListFloat;
+import org.epics.util.array.ListInteger;
+import org.epics.util.array.ListLong;
+import org.epics.util.array.ListNumber;
+import org.epics.util.array.ListShort;
+import org.epics.util.array.ListUByte;
+import org.epics.util.array.ListUInteger;
+import org.epics.util.array.ListULong;
+import org.epics.util.array.ListUShort;
+import org.epics.util.number.UnsignedConversions;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility classes to convert JSON arrays of Gson objects to and from Lists and ListNumbers. (Modified for Gson)
+ *
+ * @author <a href="mailto:changj@frib.msu.edu">Genie Jhang</a>
+ *
+ * Original description:
+ * Utility classes to convert JSON arrays to and from Lists and ListNumbers.
+ *
+ * @author carcassi
+ */
+public class GsonArrays {
+
+    /**
+     * Checks whether the array contains only numbers.
+     *
+     * @param array a JSON array
+     * @return true if all elements are JSON numbers
+     */
+    public static boolean isNumericArray(JsonArray array) {
+        for (JsonElement value : array) {
+            if (!value.getAsJsonPrimitive().isNumber()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Checks whether the array contains only strings.
+     *
+     * @param array a JSON array
+     * @return true if all elements are JSON strings
+     */
+    public static boolean isStringArray(JsonArray array) {
+        for (JsonElement value : array) {
+            if (!value.getAsJsonPrimitive().isString()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Converts the given numeric JSON array to a ListDouble.
+     * 
+     * @param array an array of numbers
+     * @return a new ListDouble
+     */
+    public static ListDouble toListDouble(JsonArray array) {
+        double[] values = new double[array.size()];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = VTypeToGson.getDoubleFromJsonString(array.get(i).toString());
+        }
+        return ArrayDouble.of(values);
+    }
+    
+    /**
+     * Converts the given numeric JSON array to a ListFloat.
+     * 
+     * @param array an array of numbers
+     * @return a new ListFloat
+     */
+    public static ListFloat toListFloat(JsonArray array) {
+        float[] values = new float[array.size()];
+        for (int i = 0; i < values.length; i++) {
+            if (array.get(i) == null) {
+                values[i] = Float.NaN;
+            } else {
+                values[i] = (float) array.get(i).getAsDouble();
+            }
+        }
+        return ArrayFloat.of(values);
+    }
+
+    /**
+     * Converts the given numeric JSON array to a {@code ListULong}.
+     * 
+     * @param array an array of numbers
+     * @return a new {@code ListULong}
+     */
+    public static ListULong toListULong(JsonArray array) {
+        long[] values = new long[array.size()];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = (long) array.get(i).getAsLong();
+        }
+        return ArrayULong.of(values);
+    }
+
+    /**
+     * Converts the given numeric JSON array to a ListLong.
+     * 
+     * @param array an array of numbers
+     * @return a new ListLong
+     */
+    public static ListLong toListLong(JsonArray array) {
+        long[] values = new long[array.size()];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = (long) array.get(i).getAsLong();
+        }
+        return ArrayLong.of(values);
+    }
+
+    /**
+     * Converts the given numeric JSON array to a {@code ListUInteger}.
+     * 
+     * @param array an array of numbers
+     * @return a new {@code ListUInteger}
+     */
+    public static ListUInteger toListUInteger(JsonArray array) {
+        int[] values = new int[array.size()];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = (int) array.get(i).getAsInt();
+        }
+        return ArrayUInteger.of(values);
+    }
+    
+    /**
+     * Converts the given numeric JSON array to a ListInteger.
+     * 
+     * @param array an array of numbers
+     * @return a new ListInteger
+     */
+    public static ListInteger toListInt(JsonArray array) {
+        int[] values = new int[array.size()];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = (int) array.get(i).getAsInt();
+        }
+        return ArrayInteger.of(values);
+    }
+
+    /**
+     * Converts the given numeric JSON array to a {@code ListUShort}.
+     *
+     * @param array an array of numbers
+     * @return a new {@code ListUShort}
+     */
+    public static ListUShort toListUShort(JsonArray array) {
+        short[] values = new short[array.size()];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = (short) array.get(i).getAsInt();
+        }
+        return ArrayUShort.of(values);
+    }
+
+    /**
+     * Converts the given numeric JSON array to a ListShort.
+     * 
+     * @param array an array of numbers
+     * @return a new ListShort
+     */
+    public static ListShort toListShort(JsonArray array) {
+        short[] values = new short[array.size()];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = (short) array.get(i).getAsInt();
+        }
+        return ArrayShort.of(values);
+    }
+
+    /**
+     * Converts the given numeric JSON array to a {@code ListUByte}.
+     * 
+     * @param array an array of numbers
+     * @return a new {@code ListUByte}
+     */
+    public static ListUByte toListUByte(JsonArray array) {
+        byte[] values = new byte[array.size()];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = (byte) array.get(i).getAsInt();
+        }
+        return ArrayUByte.of(values);
+    }
+
+    /**
+     * Converts the given numeric JSON array to a ListByte.
+     * 
+     * @param array an array of numbers
+     * @return a new ListByte
+     */
+    public static ListByte toListByte(JsonArray array) {
+        byte[] values = new byte[array.size()];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = (byte) array.get(i).getAsInt();
+        }
+        return ArrayByte.of(values);
+    }
+
+    /**
+     * Converts the given string JSON array to a List of Strings.
+     * 
+     * @param array an array of strings
+     * @return a new List of Strings
+     */
+    public static List<String> toListString(JsonArray array) {
+        List<String> strings = new ArrayList<>();
+        for (int i = 0; i < array.size(); i++) {
+            strings.add(array.get(i).getAsString());
+        }
+        return strings;
+    }
+
+
+    /**
+     * Converts the given JSON array to a List of Instants.
+     * 
+     * @param array an array
+     * @return a new List of Timestamps
+     */
+    public static List<Instant> toListTimestamp(JsonArray array) {
+        List<Instant> timestamps = new ArrayList<>();
+        for (int i = 0; i < array.size(); i++) {
+            if (array.get(i).isJsonNull()) {
+                timestamps.add(null);
+            } else {
+                timestamps.add(Instant.ofEpochSecond(array.get(i).getAsLong() / 1000, (int) (array.get(i).getAsLong() % 1000) * 1000000));
+            }
+        }
+        return timestamps;
+    }
+
+    /**
+     * Converts the given List of String to a string JSON array.
+     * 
+     * @param list a List of Strings
+     * @return an array of strings
+     */
+    public static JsonArray fromListString(List<String> list) {
+        JsonArray b = new JsonArray();
+        for (String element : list) {
+            // TODO: Not clear how to handle nulls. Converting them to empty strings.
+            if (element == null) {
+                element = "";
+            }
+            b.add(element);
+        }
+        return b;
+    }
+
+    /**
+     * Converts the given List of Timestamp to a JSON array.
+     * 
+     * @param list a List of Timestamps
+     * @return an array
+     */
+    public static JsonArray fromListTimestamp(List<Instant> list) {
+        JsonArray b = new JsonArray();
+        for (Instant element : list) {
+            if (element == null) {
+                b.add(JsonNull.INSTANCE);
+            } else {
+                b.add(element.getEpochSecond() * 1000 + element.getNano() / 1000000);
+            }
+        }
+        return b;
+    }
+
+    /**
+     * Converts the given ListNumber to a number JSON array.
+     * 
+     * @param list a list of numbers
+     * @return an array of numbers
+     */
+    public static JsonArray fromListNumber(ListNumber list) {
+        JsonArray b = new JsonArray();
+        if (list instanceof ListInteger || list instanceof ListUShort || list instanceof ListShort || list instanceof ListUByte || list instanceof ListByte) {
+            for (int i = 0; i < list.size(); i++) {
+                b.add(list.getInt(i));
+            }
+        } else if (list instanceof ListLong || list instanceof ListUInteger) {
+            for (int i = 0; i < list.size(); i++) {
+                b.add(list.getLong(i));
+            }
+        } else if (list instanceof ListULong) {
+            for (int i = 0; i < list.size(); i++) {
+                b.add(UnsignedConversions.toBigInteger(list.getLong(i)));
+            }
+        } else {
+            for (int i = 0; i < list.size(); i++) {
+                double value = list.getDouble(i);
+                if(Double.isFinite(value)){
+                    b.add(value);
+                }
+                else if (Double.isNaN(value)) {
+                    b.add(VTypeGsonMapper.NAN);
+                } else if(Double.valueOf(value).equals(Double.POSITIVE_INFINITY)){
+                    b.add(VTypeGsonMapper.POS_INF);
+                }
+                else if(Double.valueOf(value).equals(Double.NEGATIVE_INFINITY)){
+                    b.add(VTypeGsonMapper.NEG_INF);
+                }
+            }
+        }
+        return b;
+    }
+    
+}

--- a/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonDateHandler.java
+++ b/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonDateHandler.java
@@ -26,6 +26,7 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
@@ -41,10 +42,7 @@ import java.util.Date;
 public class GsonDateHandler implements JsonSerializer<Date>, JsonDeserializer<Date> {
     @Override
     public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
-        JsonObject jsonObject = new JsonObject();
-        jsonObject.addProperty("Date", src.toInstant().toEpochMilli());
-
-        return jsonObject;
+        return new JsonPrimitive(src.toInstant().toEpochMilli());
     }
 
     @Override

--- a/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonDateHandler.java
+++ b/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonDateHandler.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2020 Facility for Rare Isotope Beams
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact Information: Facility for Rare Isotope Beam,
+ *                      Michigan State University,
+ *                      East Lansing, MI 48824-1321
+ *                      http://frib.msu.edu
+ */
+package org.epics.vtype.gson;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+import java.util.Date;
+
+/**
+ * Gson De/serializer for Date object
+ *
+ * @author <a href="mailto:changj@frib.msu.edu">Genie Jhang</a>
+ */
+
+public class GsonDateHandler implements JsonSerializer<Date>, JsonDeserializer<Date> {
+    @Override
+    public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("Date", src.toInstant().toEpochMilli());
+
+        return jsonObject;
+    }
+
+    @Override
+    public Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        return new Date(json.getAsJsonPrimitive().getAsLong());
+    }
+}

--- a/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonDecimalFormatHandler.java
+++ b/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonDecimalFormatHandler.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2020 Facility for Rare Isotope Beams
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact Information: Facility for Rare Isotope Beam,
+ *                      Michigan State University,
+ *                      East Lansing, MI 48824-1321
+ *                      http://frib.msu.edu
+ */
+package org.epics.vtype.gson;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+import java.text.DecimalFormat;
+
+/**
+ * Gson De/serializer for DecimalFormat object
+ *
+ * @author <a href="mailto:changj@frib.msu.edu">Genie Jhang</a>
+ */
+
+public class GsonDecimalFormatHandler implements JsonSerializer<DecimalFormat>, JsonDeserializer<DecimalFormat> {
+    @Override
+    public JsonElement serialize(DecimalFormat src, Type typeOfSrc, JsonSerializationContext context) {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("DecimalFormat", src.toPattern());
+
+        return jsonObject;
+    }
+
+    @Override
+    public DecimalFormat deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        return new DecimalFormat(json.getAsString());
+    }
+}

--- a/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonDecimalFormatHandler.java
+++ b/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonDecimalFormatHandler.java
@@ -26,6 +26,7 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
@@ -41,10 +42,7 @@ import java.text.DecimalFormat;
 public class GsonDecimalFormatHandler implements JsonSerializer<DecimalFormat>, JsonDeserializer<DecimalFormat> {
     @Override
     public JsonElement serialize(DecimalFormat src, Type typeOfSrc, JsonSerializationContext context) {
-        JsonObject jsonObject = new JsonObject();
-        jsonObject.addProperty("DecimalFormat", src.toPattern());
-
-        return jsonObject;
+        return new JsonPrimitive(src.toPattern());
     }
 
     @Override

--- a/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonMessageBodyHandler.java
+++ b/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonMessageBodyHandler.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (C) 2020 Facility for Rare Isotope Beams
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact Information: Facility for Rare Isotope Beam,
+ *                      Michigan State University,
+ *                      East Lansing, MI 48824-1321
+ *                      http://frib.msu.edu
+ */
+package org.epics.vtype.gson;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+import com.google.gson.Gson;
+
+/**
+ * Gson MessageBody handler adapted for VType, Date, DecimalFormat objects
+ *
+ * Originally from:
+ * https://howtodoinjava.com/jersey/jax-rs-gson-example/
+ *
+ * @author <a href="mailto:changj@frib.msu.edu">Genie Jhang</a>
+ */
+
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class GsonMessageBodyHandler implements MessageBodyWriter<Object>, MessageBodyReader<Object> {
+    private static final String UTF_8 = "UTF-8";
+
+    private Gson gson;
+
+    //Customize the gson behavior here
+    private Gson getGson() {
+        if (gson == null) {
+            gson = CustomGson.getGson();
+        }
+        return gson;
+    }
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType,
+                              Annotation[] annotations, MediaType mediaType) {
+        return true;
+    }
+
+    @Override
+    public Object readFrom(Class<Object> type, Type genericType,
+                           Annotation[] annotations, MediaType mediaType,
+                           MultivaluedMap<String, String> httpHeaders, InputStream entityStream) {
+        InputStreamReader streamReader = null;
+        try {
+            streamReader = new InputStreamReader(entityStream, UTF_8);
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+        try {
+            Type jsonType;
+            if (type.equals(genericType)) {
+                jsonType = type;
+            } else {
+                jsonType = genericType;
+            }
+            return getGson().fromJson(streamReader, jsonType);
+        } finally {
+            try {
+                streamReader.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType,
+                               Annotation[] annotations, MediaType mediaType) {
+        return true;
+    }
+
+    @Override
+    public long getSize(Object object, Class<?> type, Type genericType,
+                        Annotation[] annotations, MediaType mediaType) {
+        return -1;
+    }
+
+    @Override
+    public void writeTo(Object object, Class<?> type, Type genericType,
+                        Annotation[] annotations, MediaType mediaType,
+                        MultivaluedMap<String, Object> httpHeaders,
+                        OutputStream entityStream)
+            throws IOException, WebApplicationException {
+        OutputStreamWriter writer = new OutputStreamWriter(entityStream, UTF_8);
+        try {
+            Type jsonType;
+            if (type.equals(genericType)) {
+                jsonType = type;
+            } else {
+                jsonType = genericType;
+            }
+            getGson().toJson(object, jsonType, writer);
+        } finally {
+            writer.close();
+        }
+    }
+}

--- a/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonVTypeBuilder.java
+++ b/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonVTypeBuilder.java
@@ -1,0 +1,279 @@
+/**
+ * Copyright (C) 2020 Facility for Rare Isotope Beams
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact Information: Facility for Rare Isotope Beam,
+ *                      Michigan State University,
+ *                      East Lansing, MI 48824-1321
+ *                      http://frib.msu.edu
+ */
+package org.epics.vtype.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import org.epics.util.array.ListBoolean;
+import org.epics.util.array.ListNumber;
+import org.epics.util.number.UByte;
+import org.epics.util.number.UInteger;
+import org.epics.util.number.ULong;
+import org.epics.util.number.UShort;
+import org.epics.vtype.Alarm;
+import org.epics.vtype.Display;
+import org.epics.vtype.Time;
+import org.epics.vtype.VEnum;
+import org.epics.vtype.VType;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Timestamp;
+import java.util.List;
+
+import static org.epics.vtype.gson.GsonArrays.fromListNumber;
+import static org.epics.vtype.gson.GsonArrays.fromListString;
+
+/**
+ * VType JsonObject creator for Gson
+ *
+ * @author <a href="mailto:changj@frib.msu.edu">Genie Jhang</a>
+ *
+ * Original author:
+ * @author carcassi
+ */
+class GsonVTypeBuilder extends JsonElement {
+
+    private final JsonObject jsonObject;
+
+    public GsonVTypeBuilder() {
+        jsonObject = new JsonObject();
+    }
+
+    public GsonVTypeBuilder add(String string, JsonElement jv) {
+        jsonObject.add(string, jv);
+        return this;
+    }
+
+    public GsonVTypeBuilder add(String string, String string1) {
+        jsonObject.addProperty(string, string1);
+        return this;
+    }
+
+    public GsonVTypeBuilder add(String string, BigInteger bi) {
+        jsonObject.addProperty(string, bi);
+        return this;
+    }
+
+    public GsonVTypeBuilder add(String string, BigDecimal bd) {
+        jsonObject.addProperty(string, bd);
+        return this;
+    }
+
+    public GsonVTypeBuilder add(String string, int i) {
+        jsonObject.addProperty(string, i);
+        return this;
+    }
+
+    public GsonVTypeBuilder add(String string, long l) {
+        jsonObject.addProperty(string, l);
+        return this;
+    }
+
+    public GsonVTypeBuilder add(String string, double d) {
+        if(Double.isFinite(d)){
+            jsonObject.addProperty(string, d);
+        }
+        else if (Double.isNaN(d)) {
+            jsonObject.addProperty(string, VTypeGsonMapper.NAN);
+        } else if(Double.valueOf(d).equals(Double.POSITIVE_INFINITY)){
+            jsonObject.addProperty(string, VTypeGsonMapper.POS_INF);
+        }
+        else if(Double.valueOf(d).equals(Double.NEGATIVE_INFINITY)){
+            jsonObject.addProperty(string, VTypeGsonMapper.NEG_INF);
+        }
+        return this;
+    }
+
+    public GsonVTypeBuilder addIgnoreNaN(String string, double d) {
+        if (!Double.isNaN(d)) {
+            jsonObject.addProperty(string, d);
+        }
+        return this;
+    }
+
+    public GsonVTypeBuilder add(String string, boolean bln) {
+        jsonObject.addProperty(string, bln);
+        return this;
+    }
+
+    public GsonVTypeBuilder addNull(String string) {
+        jsonObject.add(string, JsonNull.INSTANCE);
+        return this;
+    }
+
+    public GsonVTypeBuilder add(String string, GsonVTypeBuilder job) {
+        jsonObject.add(string, job);
+        return this;
+    }
+
+    public GsonVTypeBuilder add(String string, JsonArray jab) {
+        jsonObject.add(string, jab);
+        return this;
+    }
+
+    public JsonObject build() {
+        return jsonObject;
+    }
+
+    public GsonVTypeBuilder addAlarm(Alarm alarm) {
+        return add("alarm", new GsonVTypeBuilder()
+                .add("severity", alarm.getSeverity().toString())
+                .add("status", alarm.getStatus().toString())
+                .add("name", alarm.getName())
+                .build());
+    }
+    
+    public GsonVTypeBuilder addTime(Time time) {
+        return add("time", new GsonVTypeBuilder()
+                .add("unixSec", time.getTimestamp().getEpochSecond())
+                .add("nanoSec", time.getTimestamp().getNano())
+                .addNullableObject("userTag", time.getUserTag())
+                .build());
+    }
+    
+    public GsonVTypeBuilder addDisplay(Display display) {
+        return add("display", new GsonVTypeBuilder()
+                .addIgnoreNaN("lowAlarm", display.getAlarmRange().getMinimum())
+                .addIgnoreNaN("highAlarm", display.getAlarmRange().getMaximum())
+                .addIgnoreNaN("lowDisplay", display.getDisplayRange().getMinimum())
+                .addIgnoreNaN("highDisplay", display.getDisplayRange().getMaximum())
+                .addIgnoreNaN("lowWarning", display.getWarningRange().getMinimum())
+                .addIgnoreNaN("highWarning", display.getWarningRange().getMaximum())
+                .add("units", display.getUnit())
+                .build());
+    }
+    
+    public GsonVTypeBuilder addEnum(VEnum en) {
+        return add("enum", new GsonVTypeBuilder()
+                .addListString("labels", en.getDisplay().getChoices())
+                .build());
+    }
+    
+    public GsonVTypeBuilder addListString(String string, List<String> ls) {
+        add(string, fromListString(ls));
+        return this;
+    }
+    
+    public GsonVTypeBuilder addListColumnType(String string, List<Class<?>> ls) {
+        JsonArray b = new JsonArray();
+        for (Class<?> element : ls) {
+            if (element.equals(String.class)) {
+                b.add("String");
+            } else if (element.equals(double.class)) {
+                b.add("double");
+            } else if (element.equals(float.class)) {
+                b.add("float");
+            } else if (element.equals(long.class)) {
+                b.add("long");
+            } else if (element.equals(int.class)) {
+                b.add("int");
+            } else if (element.equals(short.class)) {
+                b.add("short");
+            } else if (element.equals(byte.class)) {
+                b.add("byte");
+            } else if (element.equals(Timestamp.class)) {
+                b.add("Timestamp");
+            } else {
+                throw new IllegalArgumentException("Column type " + element + " not supported");
+            }
+        }
+        add(string, b);
+        return this;
+    }
+    
+    public GsonVTypeBuilder addListNumber(String string, ListNumber ln) {
+        add(string, fromListNumber(ln));
+        return this;
+    }
+    
+    public GsonVTypeBuilder addListBoolean(String string, ListBoolean lb) {
+        JsonArray b = new JsonArray();
+        for (int i = 0; i < lb.size(); i++) {
+            b.add(lb.getBoolean(i));
+        }
+        add(string, b);
+        return this;
+    }
+    
+    public GsonVTypeBuilder addNullableObject(String string, Object o) {
+        if (o != null) {
+            addObject(string, o);
+        }
+        return this;
+    }
+    
+    public GsonVTypeBuilder addObject(String string, Object o) {
+        if (o == null) {
+            return this;
+        }
+        
+        if (o instanceof Double || o instanceof Float) {
+            add(string, ((Number) o).doubleValue());
+        } else if (o instanceof Integer || o instanceof UShort || o instanceof Short || o instanceof UByte || o instanceof Byte) {
+            add(string, ((Number) o).intValue());
+        } else if (o instanceof Long || o instanceof UInteger) {
+            add(string, ((Number) o).longValue());
+        } else if (o instanceof ULong) {
+            add(string, ((ULong) o).bigIntegerValue());
+        } else if (o instanceof ListNumber) {
+            addListNumber(string, (ListNumber) o);
+        } else if (o instanceof ListBoolean) {
+            addListBoolean(string, (ListBoolean) o);
+        } else {
+            throw new UnsupportedOperationException("Class " + o.getClass() + " not supported");
+        }
+    
+        return this;
+    }
+    
+    public GsonVTypeBuilder addType(VType vType) {
+        Class<?> clazz = VType.typeOf(vType);
+        return add("type", new GsonVTypeBuilder()
+                .add("name", clazz.getSimpleName())
+                .add("version", 1)
+                .build());
+    }
+
+    @Override
+    public JsonElement deepCopy() {
+        return null;
+    }
+
+    @Override
+    public boolean isJsonObject() {
+        return true;
+    }
+
+    @Override
+    public JsonObject getAsJsonObject() {
+        return jsonObject;
+    }
+
+    @Override
+    public String toString() {
+        return new Gson().toJson(jsonObject);
+    }
+}

--- a/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonVTypeHandler.java
+++ b/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonVTypeHandler.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2020 Facility for Rare Isotope Beams
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact Information: Facility for Rare Isotope Beam,
+ *                      Michigan State University,
+ *                      East Lansing, MI 48824-1321
+ *                      http://frib.msu.edu
+ */
+package org.epics.vtype.gson;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import org.epics.vtype.VType;
+
+import java.lang.reflect.Type;
+
+/**
+ * Custom Gson deserializer for VTypes.
+ *
+ * @author <a href="mailto:changj@frib.msu.edu">Genie Jhang</a>
+ */
+public class GsonVTypeHandler implements JsonSerializer<VType>, JsonDeserializer<VType> {
+	@Override
+	public JsonElement serialize(VType vType, Type type, JsonSerializationContext jsonSerializationContext) {
+		return VTypeToGson.toJson(vType);
+	}
+
+	@Override
+	public VType deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+		return VTypeToGson.toVType(jsonElement);
+	}
+}

--- a/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/VTypeGsonMapper.java
+++ b/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/VTypeGsonMapper.java
@@ -1,0 +1,358 @@
+/**
+ * Copyright information and license terms for this software can be
+ * found in the file LICENSE.TXT included with the distribution.
+ */
+package org.epics.vtype.gson;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.epics.util.array.ArrayBoolean;
+import org.epics.util.array.ListBoolean;
+import org.epics.util.array.ListByte;
+import org.epics.util.array.ListDouble;
+import org.epics.util.array.ListFloat;
+import org.epics.util.array.ListInteger;
+import org.epics.util.array.ListLong;
+import org.epics.util.array.ListShort;
+import org.epics.util.array.ListUByte;
+import org.epics.util.array.ListUInteger;
+import org.epics.util.array.ListULong;
+import org.epics.util.array.ListUShort;
+import org.epics.util.stats.Range;
+import org.epics.vtype.Alarm;
+import org.epics.vtype.AlarmSeverity;
+import org.epics.vtype.AlarmStatus;
+import org.epics.vtype.Display;
+import org.epics.vtype.Time;
+
+import java.text.DecimalFormat;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.epics.vtype.gson.GsonArrays.toListByte;
+import static org.epics.vtype.gson.GsonArrays.toListDouble;
+import static org.epics.vtype.gson.GsonArrays.toListFloat;
+import static org.epics.vtype.gson.GsonArrays.toListInt;
+import static org.epics.vtype.gson.GsonArrays.toListLong;
+import static org.epics.vtype.gson.GsonArrays.toListShort;
+import static org.epics.vtype.gson.GsonArrays.toListString;
+import static org.epics.vtype.gson.GsonArrays.toListTimestamp;
+import static org.epics.vtype.gson.GsonArrays.toListUByte;
+import static org.epics.vtype.gson.GsonArrays.toListUInteger;
+import static org.epics.vtype.gson.GsonArrays.toListULong;
+import static org.epics.vtype.gson.GsonArrays.toListUShort;
+
+/**
+ * Gson adapted VTypeJsonMapper
+ *
+ * @author <a href="mailto:changj@frib.msu.edu">Genie Jhang</a>
+ *
+ * Original author:
+ * @author carcassi
+ */
+class VTypeGsonMapper extends JsonElement {
+    
+    private final JsonObject json;
+
+    public static final String NAN = Double.toString(Double.NaN);
+    /**
+     * Quoted version of {@link Double#NaN}. Needed for comparison when de-serializing,
+     * as serialization of {@link Double#NaN} creates a quotes string.
+     */
+    public static final String NAN_QUOTED = "\"" + NAN + "\"";
+    public static final String POS_INF = Double.toString(Double.POSITIVE_INFINITY);
+    /**
+     * Quoted version of {@link Double#POSITIVE_INFINITY}. Needed for comparison when de-serializing,
+     * as serialization of {@link Double#POSITIVE_INFINITY} creates a quotes string.
+     */
+    public static final String POS_INF_QUOTED = "\"" + POS_INF + "\"";
+    public static final String NEG_INF = Double.toString(Double.NEGATIVE_INFINITY);
+    /**
+     * Quoted version of {@link Double#NEGATIVE_INFINITY}. Needed for comparison when de-serializing,
+     * as serialization of {@link Double#NEGATIVE_INFINITY} creates a quotes string.
+     */
+    public static final String NEG_INF_QUOTED = "\"" + NEG_INF + "\"";
+
+    public VTypeGsonMapper(JsonObject json) {
+        this.json = json;
+    }
+    
+    public String getTypeName() {
+        JsonObject type = json.getAsJsonObject("type");
+        if (type == null) {
+            return null;
+        }
+        return type.get("name").getAsString();
+    }
+    
+    public Alarm getAlarm() {
+        JsonObject alarm = json.getAsJsonObject("alarm");
+        if (alarm == null) {
+            return null;
+        }
+        return Alarm.of(AlarmSeverity.valueOf(alarm.get("severity").getAsString()), AlarmStatus.valueOf(alarm.get("status").getAsString()), alarm.get("name").getAsString());
+    }
+    
+    public Time getTime() {
+        VTypeGsonMapper time = getJsonObject("time");
+        if (time == null) {
+            return null;
+        }
+        return Time.of(Instant.ofEpochSecond(time.getInt("unixSec"), time.getInt("nanoSec")), time.getInteger("userTag"), true);
+    }
+    
+    public Display getDisplay() {
+        VTypeGsonMapper display = getJsonObject("display");
+        if (display == null) {
+            return null;
+        }
+        return Display.of(Range.of(display.getNotNullDouble("lowDisplay"), display.getNotNullDouble("highDisplay")),
+                Range.of(display.getNotNullDouble("lowAlarm"), display.getNotNullDouble("highAlarm")),
+                Range.of(display.getNotNullDouble("lowWarning"), display.getNotNullDouble("highWarning")),
+                Range.of(display.getNotNullDouble("lowControl"), display.getNotNullDouble("highControl")),
+                display.getString("units"), new DecimalFormat());
+    }
+    
+    public ListDouble getListDouble(String string) {
+        JsonArray array = getJsonArray(string);
+        return toListDouble(array);
+    }
+    
+    
+    public ListFloat getListFloat(String string) {
+        JsonArray array = getJsonArray(string);
+        return toListFloat(array);
+    }
+    
+    public ListULong getListULong(String string) {
+        JsonArray array = getJsonArray(string);
+        return toListULong(array);
+    }
+    
+    public ListLong getListLong(String string) {
+        JsonArray array = getJsonArray(string);
+        return toListLong(array);
+    }
+    
+    
+    public ListUInteger getListUInteger(String string) {
+        JsonArray array = getJsonArray(string);
+        return toListUInteger(array);
+    }
+    
+    public ListInteger getListInt(String string) {
+        JsonArray array = getJsonArray(string);
+        return toListInt(array);
+    }
+    
+    
+    public ListUShort getListUShort(String string) {
+        JsonArray array = getJsonArray(string);
+        return toListUShort(array);
+    }
+    
+    public ListShort getListShort(String string) {
+        JsonArray array = getJsonArray(string);
+        return toListShort(array);
+    }
+    
+    
+    public ListUByte getListUByte(String string) {
+        JsonArray array = getJsonArray(string);
+        return toListUByte(array);
+    }
+    
+    public ListByte getListByte(String string) {
+        JsonArray array = getJsonArray(string);
+        return toListByte(array);
+    }
+    
+
+    public ListBoolean getListBoolean(String string) {
+        JsonArray array = getJsonArray(string);
+        boolean[] values = new boolean[array.size()];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = array.get(i).getAsBoolean();
+        }
+        return new ArrayBoolean(values);
+    }
+    
+    public List<String> getListString(String string) {
+        JsonArray array = getJsonArray(string);
+        return toListString(array);
+    }
+    
+
+    public List<Class<?>> getColumnTypes(String string) {
+        JsonArray array = getJsonArray(string);
+        List<Class<?>> types = new ArrayList<>();
+        for (int i = 0; i < array.size(); i++) {
+            String type = array.get(i).getAsString();
+            if ("String".equals(type)) {
+                types.add(String.class);
+            } else if ("double".equals(type)) {
+                types.add(double.class);
+            } else if ("float".equals(type)) {
+                types.add(float.class);
+            } else if ("long".equals(type)) {
+                types.add(long.class);
+            } else if ("int".equals(type)) {
+                types.add(int.class);
+            } else if ("short".equals(type)) {
+                types.add(short.class);
+            } else if ("byte".equals(type)) {
+                types.add(byte.class);
+            } else if ("Timestamp".equals(type)) {
+                types.add(Instant.class);
+            } else {
+                throw new IllegalArgumentException("Column type " + type + " not supported");
+            }
+        }
+        return types;
+    }
+
+    public List<Object> getColumnValues(String string, List<Class<?>> types) {
+        JsonArray array = getJsonArray(string);
+        List<Object> result = new ArrayList<>();
+        for (int i = 0; i < types.size(); i++) {
+            Class<?> type = types.get(i);
+            if (String.class.equals(type)) {
+                result.add(toListString(array.get(i).getAsJsonArray()));
+            } else if (double.class.equals(type)) {
+                result.add(toListDouble(array.get(i).getAsJsonArray()));
+            } else if (float.class.equals(type)) {
+                result.add(toListFloat(array.get(i).getAsJsonArray()));
+            } else if (long.class.equals(type)) {
+                result.add(toListLong(array.get(i).getAsJsonArray()));
+            } else if (int.class.equals(type)) {
+                result.add(toListInt(array.get(i).getAsJsonArray()));
+            } else if (short.class.equals(type)) {
+                result.add(toListShort(array.get(i).getAsJsonArray()));
+            } else if (byte.class.equals(type)) {
+                result.add(toListByte(array.get(i).getAsJsonArray()));
+            } else if (Instant.class.equals(type)) {
+                result.add(toListTimestamp(array.get(i).getAsJsonArray()));
+            } else {
+                throw new IllegalArgumentException("Column type " + type + " not supported");
+            }
+        }
+        return result;
+    }
+    
+    public Integer getInteger(String string) {
+        if (isNull(string)) {
+            return null;
+        }
+        return getInt(string);
+    }
+    
+    public Double getNotNullDouble(String string) {
+        if (isNull(string)) {
+            return Double.NaN;
+        }
+        return getJsonNumber(string).getAsDouble();
+    }
+
+    public JsonArray getJsonArray(String string) {
+        return json.get(string).getAsJsonArray();
+    }
+
+    public VTypeGsonMapper getJsonObject(String string) {
+        return new VTypeGsonMapper(json.get(string).getAsJsonObject());
+    }
+
+    public JsonElement getJsonNumber(String string) {
+        return json.get(string);
+    }
+
+    public JsonElement getJsonString(String string) {
+        return json.get(string);
+    }
+
+    public String getString(String string) {
+        return json.get(string).getAsString();
+    }
+
+    public String getString(String string, String string1) {
+        return json.get(string).isJsonNull() ? string1 : json.get(string).getAsString();
+    }
+
+    public int getInt(String string) {
+        return json.get(string).getAsInt();
+    }
+
+    public int getInt(String string, int i) {
+        return json.get(string).isJsonNull() ? i : json.get(string).getAsInt();
+    }
+
+    public boolean getBoolean(String string) {
+        return json.get(string).getAsBoolean();
+    }
+
+    public boolean getBoolean(String string, boolean bln) {
+        return json.get(string).isJsonNull() ? bln : json.get(string).getAsBoolean();
+    }
+
+    public boolean isNull(String string) {
+        return json.get(string) == null || json.get(string).isJsonNull();
+    }
+
+    public int size() {
+        return json.size();
+    }
+
+    public boolean isEmpty() {
+        return json.isJsonNull();
+    }
+
+    public boolean containsKey(Object key) {
+        return json.get(key.toString()) != null && !json.get(key.toString()).isJsonNull();
+    }
+
+    public boolean containsValue(Object value) {
+        return json.get(value.toString()) != null && !json.get(value.toString()).isJsonNull();
+    }
+
+    public JsonElement get(Object key) {
+        return json.get((String)key);
+    }
+
+    public JsonElement put(String key, JsonElement value) {
+        json.add(key, value);
+        return json.get(key);
+    }
+
+    public JsonElement remove(Object key) {
+        return json.remove((String)key);
+    }
+
+    public void putAll(Map<? extends String, ? extends JsonElement> m) {
+        m.forEach(json::add);
+    }
+
+    public void clear() {
+    }
+
+    public Set<String> keySet() {
+        return json.keySet();
+    }
+
+    public Collection<JsonElement> values() {
+        return Collections.emptyList();
+    }
+
+    public Set<Map.Entry<String, JsonElement>> entrySet() {
+        return json.entrySet();
+    }
+
+    @Override
+    public JsonElement deepCopy() {
+        return null;
+    }
+}

--- a/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/VTypeToGson.java
+++ b/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/VTypeToGson.java
@@ -1,0 +1,244 @@
+/**
+ * Copyright information and license terms for this software can be
+ * found in the file LICENSE.TXT included with the distribution.
+ */
+package org.epics.vtype.gson;
+
+import com.google.gson.JsonElement;
+import org.epics.util.array.ListNumber;
+import org.epics.util.number.UByte;
+import org.epics.util.number.UInteger;
+import org.epics.util.number.ULong;
+import org.epics.util.number.UShort;
+import org.epics.vtype.EnumDisplay;
+import org.epics.vtype.VDouble;
+import org.epics.vtype.VEnum;
+import org.epics.vtype.VNumber;
+import org.epics.vtype.VNumberArray;
+import org.epics.vtype.VString;
+import org.epics.vtype.VType;
+
+import java.util.List;
+
+/**
+ * Gson adapted VTypeToJson
+ *
+ * @author <a href="mailto:changj@frib.msu.edu">Genie Jhang</a>
+ *
+ * Original author:
+ * @author carcassi
+ */
+public class VTypeToGson {
+
+    static VType toVType(JsonElement json) {
+        switch(typeNameOf(json)) {
+            case "VDouble":
+            case "VFloat":
+            case "VULong":
+            case "VLong":
+            case "VUInt":
+            case "VInt":
+            case "VUShort":
+            case "VShort":
+            case "VUByte":
+            case "VByte":
+                return toVNumber(json);
+            case "VDoubleArray":
+            case "VFloatArray":
+            case "VULongArray":
+            case "VLongArray":
+            case "VUIntArray":
+            case "VIntArray":
+            case "VUShortArray":
+            case "VShortArray":
+            case "VUByteArray":
+            case "VByteArray":
+                return toVNumberArray(json);
+            case "VString":
+                return toVString(json);
+            case "VEnum":
+                return toVEnum(json);
+            default:
+                throw new UnsupportedOperationException("Not implemented yet");
+        }
+    }
+    
+    static String typeNameOf(JsonElement json) {
+        JsonElement type = json.getAsJsonObject().get("type");
+        if (type == null) {
+            return null;
+        }
+        return type.getAsJsonObject().get("name").getAsString();
+    }
+    
+    static JsonElement toJson(VType vType) {
+        if (vType instanceof VNumber) {
+            return toJson((VNumber) vType);
+        } else if (vType instanceof VNumberArray) {
+            return toJson((VNumberArray) vType);
+        } else if (vType instanceof VString) {
+            return toJson((VString) vType);
+        } else if (vType instanceof VEnum) {
+            return toJson((VEnum) vType);
+        }
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+    
+    static VNumber toVNumber(JsonElement json) {
+        VTypeGsonMapper mapper = new VTypeGsonMapper(json.getAsJsonObject());
+        Number value;
+        switch(mapper.getTypeName()) {
+            case "VDouble":
+                Double doubleValue = json.getAsJsonObject().get("value").getAsDouble();
+                if(doubleValue != null){
+                    return VDouble.of(doubleValue, mapper.getAlarm(), mapper.getTime(), mapper.getDisplay());
+                }
+                value = mapper.getJsonNumber("value").getAsDouble();
+                break;
+            case "VFloat":
+                value = (float) mapper.getJsonNumber("value").getAsDouble();
+                break;
+            case "VULong":
+                value = new ULong(mapper.getJsonNumber("value").getAsLong());
+                break;
+            case "VLong":
+                value = (long) mapper.getJsonNumber("value").getAsLong();
+                break;
+            case "VUInt":
+                value = new UInteger(mapper.getJsonNumber("value").getAsInt());
+                break;
+            case "VInt":
+                value = (int) mapper.getJsonNumber("value").getAsInt();
+                break;
+            case "VUShort":
+                value = new UShort((short) mapper.getJsonNumber("value").getAsInt());
+                break;
+            case "VShort":
+                value = (short) mapper.getJsonNumber("value").getAsInt();
+                break;
+            case "VUByte":
+                value = new UByte((byte) mapper.getJsonNumber("value").getAsInt());
+                break;
+            case "VByte":
+                value = (byte) mapper.getJsonNumber("value").getAsInt();
+                break;
+            default:
+                throw new UnsupportedOperationException("Not implemented yet");
+        }
+        return VNumber.of(value, mapper.getAlarm(), mapper.getTime(), mapper.getDisplay());
+    }
+    
+    static VString toVString(JsonElement json) {
+        VTypeGsonMapper mapper = new VTypeGsonMapper(json.getAsJsonObject());
+        return VString.of(mapper.getString("value"), mapper.getAlarm(), mapper.getTime());
+    }
+    
+    static VEnum toVEnum(JsonElement json) {
+        VTypeGsonMapper mapper = new VTypeGsonMapper(json.getAsJsonObject());
+        List<String> labels = mapper.getJsonObject("enum").getListString("labels");
+        return VEnum.of(mapper.getInt("value"), EnumDisplay.of(labels), mapper.getAlarm(), mapper.getTime());
+    }
+    
+    static VNumberArray toVNumberArray(JsonElement json) {
+        VTypeGsonMapper mapper = new VTypeGsonMapper(json.getAsJsonObject());
+        ListNumber value;
+        switch(mapper.getTypeName()) {
+            case "VDoubleArray":
+                value = mapper.getListDouble("value");
+                break;
+            case "VFloatArray":
+                value = mapper.getListFloat("value");
+                break;
+            case "VULongArray":
+                value = mapper.getListULong("value");
+                break;
+            case "VLongArray":
+                value = mapper.getListLong("value");
+                break;
+            case "VUIntArray":
+                value = mapper.getListUInteger("value");
+                break;
+            case "VIntArray":
+                value = mapper.getListInt("value");
+                break;
+            case "VUShortArray":
+                value = mapper.getListUShort("value");
+                break;
+            case "VShortArray":
+                value = mapper.getListShort("value");
+                break;
+            case "VUByteArray":
+                value = mapper.getListUByte("value");
+                break;
+            case "VByteArray":
+                value = mapper.getListByte("value");
+                break;
+            default:
+                throw new UnsupportedOperationException("Not implemented yet");
+        }
+        return VNumberArray.of(value, mapper.getAlarm(), mapper.getTime(), mapper.getDisplay());
+    }
+    
+    static JsonElement toJson(VNumber vNumber) {
+        return new GsonVTypeBuilder()
+                .addType(vNumber)
+                .addObject("value", vNumber.getValue())
+                .addAlarm(vNumber.getAlarm())
+                .addTime(vNumber.getTime())
+                .addDisplay(vNumber.getDisplay())
+                .build();
+    }
+    
+    static JsonElement toJson(VNumberArray vNumberArray) {
+        return new GsonVTypeBuilder()
+                .addType(vNumberArray)
+                .addObject("value", vNumberArray.getData())
+                .addAlarm(vNumberArray.getAlarm())
+                .addTime(vNumberArray.getTime())
+                .addDisplay(vNumberArray.getDisplay())
+                .build();
+    }
+    
+    static JsonElement toJson(VString vString) {
+        return new GsonVTypeBuilder()
+                .addType(vString)
+                .add("value", vString.getValue())
+                .addAlarm(vString.getAlarm())
+                .addTime(vString.getTime())
+                .build();
+    }
+    
+    static JsonElement toJson(VEnum vEnum) {
+        return new GsonVTypeBuilder()
+                .addType(vEnum)
+                .add("value", vEnum.getIndex())
+                .addAlarm(vEnum.getAlarm())
+                .addTime(vEnum.getTime())
+                .addEnum(vEnum)
+                .build();
+    }
+
+    /**
+     * Converts an input (JSON) string to a {@link Double}, taking into account the special cases
+     * {@link Double#NaN}, {@link Double#POSITIVE_INFINITY} and {@link Double#NEGATIVE_INFINITY}.
+     * If the input string is not parseable as a double (including the special cases), a
+     * {@link NumberFormatException} is thrown.
+     * @param valueAsString
+     * @return A valid double number, otherwise
+     * {@link Double#NaN}, {@link Double#POSITIVE_INFINITY} and {@link Double#NEGATIVE_INFINITY}.
+     */
+    public static Double getDoubleFromJsonString(String valueAsString){
+        if(VTypeGsonMapper.NAN_QUOTED.equals(valueAsString)){
+            return Double.NaN;
+        }
+        else if(VTypeGsonMapper.POS_INF_QUOTED.equals(valueAsString)){
+            return Double.POSITIVE_INFINITY;
+        }
+        else if(VTypeGsonMapper.NEG_INF_QUOTED.equals(valueAsString)){
+            return Double.NEGATIVE_INFINITY;
+        }
+        else{
+            return Double.parseDouble(valueAsString);
+        }
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/java/org/epics/vtype/gson/ChangeFailedToReference.java
+++ b/epics-vtype/vtype-gson/src/test/java/org/epics/vtype/gson/ChangeFailedToReference.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright information and license terms for this software can be
+ * found in the file LICENSE.TXT included with the distribution.
+ */
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.epics.vtype.gson;
+
+import java.io.File;
+
+/**
+ *
+ * @author carcassi
+ */
+public class ChangeFailedToReference {
+
+    /**
+     * @param args the command line arguments
+     */
+    public static void main(String[] args) {
+        File file = new File("src/test/resources/org/epics/vtype/gson/");
+        for (File failed : file.listFiles((File dir, String name) -> name.contains(".failed."))) {
+            File reference = new File(failed.getPath().subSequence(0, failed.getPath().indexOf(".failed.")) + ".json");
+            if (reference.exists()) {
+                reference.delete();
+            }
+            failed.renameTo(reference);
+        }
+    }
+    
+}

--- a/epics-vtype/vtype-gson/src/test/java/org/epics/vtype/gson/GsonArraysTest.java
+++ b/epics-vtype/vtype-gson/src/test/java/org/epics/vtype/gson/GsonArraysTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright information and license terms for this software can be
+ * found in the file LICENSE.TXT included with the distribution.
+ */
+package org.epics.vtype.gson;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParser;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+import static org.epics.vtype.gson.GsonArrays.*;
+
+/**
+ *
+ * @author carcassi
+ */
+public class GsonArraysTest {
+    
+    public String integerArray = "[0,1,2]";
+    public String doubleArray = "[0.0,0.1,0.2]";
+    public String stringArray = "[\"A\",\"B\",\"C\"]";
+    public String mixedArray = "[\"A\",1,\"C\"]";
+    
+    public JsonArray parseJson(String json) {
+        return JsonParser.parseString(json).getAsJsonArray();
+    }
+
+    @Test
+    public void isNumericArray1() {
+        assertThat(isNumericArray(parseJson(integerArray)), equalTo(true));
+        assertThat(isNumericArray(parseJson(doubleArray)), equalTo(true));
+        assertThat(isNumericArray(parseJson(stringArray)), equalTo(false));
+        assertThat(isNumericArray(parseJson(mixedArray)), equalTo(false));
+    }
+
+    @Test
+    public void isStringArray1() {
+        assertThat(isStringArray(parseJson(integerArray)), equalTo(false));
+        assertThat(isStringArray(parseJson(doubleArray)), equalTo(false));
+        assertThat(isStringArray(parseJson(stringArray)), equalTo(true));
+        assertThat(isStringArray(parseJson(mixedArray)), equalTo(false));
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/java/org/epics/vtype/gson/VTypeToGsonTest.java
+++ b/epics-vtype/vtype-gson/src/test/java/org/epics/vtype/gson/VTypeToGsonTest.java
@@ -1,0 +1,358 @@
+/**
+ * Copyright information and license terms for this software can be
+ * found in the file LICENSE.TXT included with the distribution.
+ */
+package org.epics.vtype.gson;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.reflect.TypeToken;
+import org.epics.util.array.ArrayByte;
+import org.epics.util.array.ArrayDouble;
+import org.epics.util.array.ArrayFloat;
+import org.epics.util.array.ArrayInteger;
+import org.epics.util.array.ArrayLong;
+import org.epics.util.array.ArrayShort;
+import org.epics.util.array.ArrayUByte;
+import org.epics.util.array.ArrayUInteger;
+import org.epics.util.array.ArrayULong;
+import org.epics.util.array.ArrayUShort;
+import org.epics.util.number.UByte;
+import org.epics.util.number.UInteger;
+import org.epics.util.number.ULong;
+import org.epics.util.number.UShort;
+import org.epics.vtype.Alarm;
+import org.epics.vtype.AlarmSeverity;
+import org.epics.vtype.AlarmStatus;
+import org.epics.vtype.Display;
+import org.epics.vtype.EnumDisplay;
+import org.epics.vtype.Time;
+import org.epics.vtype.VByte;
+import org.epics.vtype.VByteArray;
+import org.epics.vtype.VDouble;
+import org.epics.vtype.VDoubleArray;
+import org.epics.vtype.VEnum;
+import org.epics.vtype.VFloat;
+import org.epics.vtype.VFloatArray;
+import org.epics.vtype.VInt;
+import org.epics.vtype.VIntArray;
+import org.epics.vtype.VLong;
+import org.epics.vtype.VLongArray;
+import org.epics.vtype.VShort;
+import org.epics.vtype.VShortArray;
+import org.epics.vtype.VString;
+import org.epics.vtype.VType;
+import org.epics.vtype.VUByte;
+import org.epics.vtype.VUByteArray;
+import org.epics.vtype.VUInt;
+import org.epics.vtype.VUIntArray;
+import org.epics.vtype.VULong;
+import org.epics.vtype.VULongArray;
+import org.epics.vtype.VUShort;
+import org.epics.vtype.VUShortArray;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Testing Gson de/serializer.
+ *
+ * @author <a href='mailto:changj@frib.msu.edu'>Genie Jhang</a>
+ *
+ * Original author:
+ * @author carcassi
+ */
+public class VTypeToGsonTest {
+
+    /**
+     * Serializes the given value and compares the output with the given JSON file.
+     *
+     * @param value the value to serialize
+     * @param expectedJsonFileName the filename to compare
+     */
+    public static void testSerialization(VType value, String expectedJsonFileName) {
+        JsonElement json = VTypeToGson.toJson(value);
+
+        boolean success = false;
+        try {
+            JsonElement reference = loadJson(expectedJsonFileName + ".json");
+            assertThat(json, equalTo(reference));
+            success = true;
+        } finally {
+            File failedJsonFile = new File("src/test/resources/org/epics/vtype/gson/" + expectedJsonFileName + ".failed.json");
+            if (!success) {
+                saveErrorJson(json, failedJsonFile);
+            } else {
+                if (failedJsonFile.exists()) {
+                    failedJsonFile.delete();
+                }
+            }
+        }
+    }
+
+    /**
+     * Deserializes the JSON file and compares the value with the given VType object.
+     *
+     * @param jsonFileName the JSON file to deserialize
+     * @param expected the object to compare to
+     */
+    public static void testDeserialization(String jsonFileName, VType expected) {
+        VType actual = VTypeToGson.toVType(loadJson(jsonFileName + ".json"));
+        assertThat(actual, equalTo(expected));
+    }
+
+    public static JsonElement loadJson(String jsonFile) {
+        InputStream stream = VTypeToGsonTest.class.getResourceAsStream(jsonFile);
+        InputStreamReader inputStreamReader = new InputStreamReader(stream);
+        return JsonParser.parseReader(inputStreamReader);
+    }
+
+    public static void saveErrorJson(JsonElement json, File jsonFile) {
+        try (FileWriter fw = new FileWriter(jsonFile)) {
+            fw.append(CustomGson.getGson().toJson(json));
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Test
+    public void vDouble1() {
+        VDouble vDouble1 = VDouble.of(3.14, Alarm.of(AlarmSeverity.MINOR, AlarmStatus.DB, "LOW"), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vDouble1, "VDouble1");
+        testDeserialization("VDouble1", vDouble1);
+        testDeserialization("VDouble1a", vDouble1);
+    }
+
+    @Test
+    public void vFloat1() {
+        VFloat vFloat1 = VFloat.of((float) 3.125, Alarm.of(AlarmSeverity.MINOR, AlarmStatus.DB, "HIGH"), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vFloat1, "VFloat1");
+        testDeserialization("VFloat1", vFloat1);
+        testDeserialization("VFloat1a", vFloat1);
+    }
+
+    @Test
+    public void vULong1() {
+        VULong vULong1 = VULong.of(new ULong(-1), Alarm.of(AlarmSeverity.MINOR, AlarmStatus.DB, "HIGH"), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vULong1, "VULong1");
+        testDeserialization("VULong1", vULong1);
+    }
+
+    @Test
+    public void vLong1() {
+        VLong vLong1 = VLong.of(313L, Alarm.of(AlarmSeverity.MINOR, AlarmStatus.DB, "HIGH"), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vLong1, "VLong1");
+        testDeserialization("VLong1", vLong1);
+        testDeserialization("VLong1a", vLong1);
+    }
+
+    @Test
+    public void vUInt1() {
+        VUInt vUInt1 = VUInt.of(new UInteger(-1), Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vUInt1, "VUInt1");
+        testDeserialization("VUInt1", vUInt1);
+    }
+
+    @Test
+    public void vInt1() {
+        VInt vInt1 = VInt.of(314, Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vInt1, "VInt1");
+        testDeserialization("VInt1", vInt1);
+        testDeserialization("VInt1a", vInt1);
+    }
+
+    @Test
+    public void vUShort1() {
+        VUShort vUShort1 = VUShort.of(new UShort((short) -1), Alarm.of(AlarmSeverity.MINOR, AlarmStatus.DB, "HIGH"), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vUShort1, "VUShort1");
+        testDeserialization("VUShort1", vUShort1);
+    }
+
+    @Test
+    public void vShort1() {
+        VShort vShort1 = VShort.of((short) 314, Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vShort1, "VShort1");
+        testDeserialization("VShort1", vShort1);
+        testDeserialization("VShort1a", vShort1);
+    }
+
+    @Test
+    public void vUByte1() {
+        VUByte vUByte1 = VUByte.of(new UByte((byte) -1), Alarm.of(AlarmSeverity.MINOR, AlarmStatus.DB, "HIGH"), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vUByte1, "VUByte1");
+        testDeserialization("VUByte1", vUByte1);
+    }
+
+    @Test
+    public void vByte1() {
+        VByte vByte1 = VByte.of((byte) 31, Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vByte1, "VByte1");
+        testDeserialization("VByte1", vByte1);
+        testDeserialization("VByte1a", vByte1);
+    }
+
+    @Test
+    public void vString1() {
+        VString vString1 = VString.of("Flower", Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)));
+        testSerialization(vString1, "VString1");
+        testDeserialization("VString1", vString1);
+        testDeserialization("VString1a", vString1);
+    }
+
+    @Test
+    public void vEnum1() {
+        VEnum vEnum1 = VEnum.of(1, EnumDisplay.of(Arrays.asList("One", "Two", "Three")), Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)));
+        testSerialization(vEnum1, "VEnum1");
+        testDeserialization("VEnum1", vEnum1);
+        testDeserialization("VEnum1a", vEnum1);
+    }
+
+    @Test
+    public void vDoubleArray1() {
+        VDoubleArray vDoubleArray1 = VDoubleArray.of(ArrayDouble.of(0, 1, 2), Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vDoubleArray1, "VDoubleArray1");
+        testDeserialization("VDoubleArray1", vDoubleArray1);
+        testDeserialization("VDoubleArray1a", vDoubleArray1);
+    }
+
+    @Test
+    public void vFloatArray1() {
+        VFloatArray vFloatArray1 = VFloatArray.of(ArrayFloat.of(0, 1, 2), Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vFloatArray1, "VFloatArray1");
+        testDeserialization("VFloatArray1", vFloatArray1);
+        testDeserialization("VFloatArray1a", vFloatArray1);
+    }
+
+    @Test
+    public void vULongArray1() {
+        VULongArray vULongArray1 = VULongArray.of(ArrayULong.of(-1, -2, -3), Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vULongArray1, "VULongArray1");
+        testDeserialization("VULongArray1", vULongArray1);
+    }
+
+    @Test
+    public void vLongArray1() {
+        VLongArray vLongArray1 = VLongArray.of(ArrayLong.of(0, 1, 2), Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vLongArray1, "VLongArray1");
+        testDeserialization("VLongArray1", vLongArray1);
+    }
+
+    @Test
+    public void vUIntArray1() {
+        VUIntArray vUIntArray1 = VUIntArray.of(ArrayUInteger.of(-1, -2, -3), Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vUIntArray1, "VUIntArray1");
+        testDeserialization("VUIntArray1", vUIntArray1);
+    }
+
+    @Test
+    public void vIntArray1() {
+        VIntArray vIntArray1 = VIntArray.of(ArrayInteger.of(0, 1, 2), Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vIntArray1, "VIntArray1");
+        testDeserialization("VIntArray1", vIntArray1);
+    }
+
+    @Test
+    public void vUShortArray1() {
+        VUShortArray vUShortArray1 = VUShortArray.of(ArrayUShort.of(new short[] {-1, -2, -3}), Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vUShortArray1, "VUShortArray1");
+        testDeserialization("VUShortArray1", vUShortArray1);
+    }
+
+    @Test
+    public void vShortArray1() {
+        VShortArray vShortArray1 = VShortArray.of(ArrayShort.of(new short[] {0, 1, 2}), Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vShortArray1, "VShortArray1");
+        testDeserialization("VShortArray1", vShortArray1);
+    }
+
+    @Test
+    public void vUByteArray1() {
+        VUByteArray vUByteArray1 = VUByteArray.of(ArrayUByte.of(new byte[] {-1, -2, -3}), Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vUByteArray1, "VUByteArray1");
+        testDeserialization("VUByteArray1", vUByteArray1);
+    }
+
+    @Test
+    public void vByteArray1() {
+        VByteArray vByteArray1 = VByteArray.of(ArrayByte.of(new byte[] {0, 1, 2}), Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vByteArray1, "VByteArray1");
+        testDeserialization("VByteArray1", vByteArray1);
+        testDeserialization("VByteArray1a", vByteArray1);
+    }
+
+    /**
+     * Tests serialization and de-serialization of a Double.NaN. See {@link GsonVTypeBuilder#add} and
+     * {@link VTypeToGson#toVNumber}
+     */
+    @Test
+    public void testDoubleNaN(){
+        VDouble vDouble = VDouble.of(Double.NaN, Alarm.none(), Time.of(Instant.EPOCH), Display.none());
+        JsonElement jsonElement = VTypeToGson.toJson(vDouble);
+        assertEquals("NaN", jsonElement.getAsJsonObject().get("value").getAsString());
+        vDouble = (VDouble)VTypeToGson.toVType(jsonElement);
+        assertTrue(Double.isNaN(vDouble.getValue()));
+    }
+
+    @Test
+    public void testDoublePositiveInfinity(){
+        VDouble vDouble = VDouble.of(Double.POSITIVE_INFINITY, Alarm.none(), Time.of(Instant.EPOCH), Display.none());
+        JsonElement jsonElement = VTypeToGson.toJson(vDouble);
+        assertEquals(Double.toString(Double.POSITIVE_INFINITY), jsonElement.getAsJsonObject().get("value").getAsString());
+        vDouble = (VDouble)VTypeToGson.toVType(jsonElement);
+        assertTrue(vDouble.getValue().equals(Double.POSITIVE_INFINITY));
+    }
+
+    @Test
+    public void testDoubleNegativeInfinity(){
+        VDouble vDouble = VDouble.of(Double.NEGATIVE_INFINITY, Alarm.none(), Time.of(Instant.EPOCH), Display.none());
+        JsonElement jsonElement = VTypeToGson.toJson(vDouble);
+        assertEquals(VTypeGsonMapper.NEG_INF, jsonElement.getAsJsonObject().get("value").getAsString());
+        vDouble = (VDouble)VTypeToGson.toVType(jsonElement);
+        assertTrue(vDouble.getValue().equals(Double.NEGATIVE_INFINITY));
+    }
+
+    @Test
+    public void testDoubleNaNInArray(){
+        VDoubleArray vDoubleArray1 = VDoubleArray.of(ArrayDouble.of(0, Double.NaN, 2), Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        JsonElement jsonElement = VTypeToGson.toJson(vDoubleArray1);
+        List valueObject = CustomGson.getGson().fromJson(jsonElement.getAsJsonObject().get("value"), new TypeToken<List<JsonPrimitive>>() {}.getType());
+        assertEquals(VTypeGsonMapper.NAN_QUOTED, valueObject.get(1).toString());
+        vDoubleArray1 = (VDoubleArray)VTypeToGson.toVType(jsonElement);
+        assertTrue(Double.isNaN(vDoubleArray1.getData().getDouble(1)));
+    }
+
+    @Test
+    public void testDoublePositiveInfinityInArray(){
+        VDoubleArray vDoubleArray1 = VDoubleArray.of(ArrayDouble.of(0, Double.POSITIVE_INFINITY, 2), Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        JsonElement jsonElement = VTypeToGson.toJson(vDoubleArray1);
+        List valueObject = CustomGson.getGson().fromJson(jsonElement.getAsJsonObject().get("value"), new TypeToken<List<JsonPrimitive>>() {}.getType());
+        assertEquals(VTypeGsonMapper.POS_INF_QUOTED, valueObject.get(1).toString());
+        vDoubleArray1 = (VDoubleArray)VTypeToGson.toVType(jsonElement);
+        assertTrue(Double.isInfinite(vDoubleArray1.getData().getDouble(1)));
+    }
+
+    @Test
+    public void testDoubleNegativeInfinityInArray(){
+        VDoubleArray vDoubleArray1 = VDoubleArray.of(ArrayDouble.of(0, Double.NEGATIVE_INFINITY, 2), Alarm.none(), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        JsonElement jsonElement = VTypeToGson.toJson(vDoubleArray1);
+        List valueObject = CustomGson.getGson().fromJson(jsonElement.getAsJsonObject().get("value"), new TypeToken<List<JsonPrimitive>>() {}.getType());
+        assertEquals(VTypeGsonMapper.NEG_INF_QUOTED, valueObject.get(1).toString());
+        vDoubleArray1 = (VDoubleArray)VTypeToGson.toVType(jsonElement);
+        assertTrue(Double.isInfinite(vDoubleArray1.getData().getDouble(1)));
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void testGetDoubleFromStringNonParsableValue(){
+        VTypeToGson.getDoubleFromJsonString("invalid");
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/java/org/epics/vtype/gson/VTypeToGsonTest.java
+++ b/epics-vtype/vtype-gson/src/test/java/org/epics/vtype/gson/VTypeToGsonTest.java
@@ -81,14 +81,14 @@ public class VTypeToGsonTest {
      * @param expectedJsonFileName the filename to compare
      */
     public static void testSerialization(VType value, String expectedJsonFileName) {
-        JsonElement json = VTypeToGson.toJson(value);
+        JsonElement json = JsonParser.parseString(CustomGson.getGson().toJson(value, VType.class));
 
         boolean success = false;
         try {
             JsonElement reference = loadJson(expectedJsonFileName + ".json");
             assertThat(json, equalTo(reference));
             success = true;
-        } finally {
+        } finally{
             File failedJsonFile = new File("src/test/resources/org/epics/vtype/gson/" + expectedJsonFileName + ".failed.json");
             if (!success) {
                 saveErrorJson(json, failedJsonFile);
@@ -107,7 +107,7 @@ public class VTypeToGsonTest {
      * @param expected the object to compare to
      */
     public static void testDeserialization(String jsonFileName, VType expected) {
-        VType actual = VTypeToGson.toVType(loadJson(jsonFileName + ".json"));
+        VType actual = CustomGson.getGson().fromJson(loadJson(jsonFileName + ".json"), VType.class);
         assertThat(actual, equalTo(expected));
     }
 

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VByte1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VByte1.json
@@ -1,0 +1,19 @@
+{
+    "type":{
+        "name":"VByte",
+        "version":1
+    },
+    "value":31,
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VByte1a.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VByte1a.json
@@ -1,0 +1,26 @@
+{
+   "type":{
+      "name":"VByte",
+      "version":1
+   },
+   "value":31,
+   "alarm":{
+      "severity":"NONE",
+      "status":"NONE",
+      "name":"None"
+   },
+   "time":{
+      "unixSec":0,
+      "nanoSec":0,
+      "userTag":null
+   },
+   "display":{
+      "lowAlarm":null,
+      "highAlarm":null,
+      "lowDisplay":null,
+      "highDisplay":null,
+      "lowWarning":null,
+      "highWarning":null,
+      "units":""
+   }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VByteArray1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VByteArray1.json
@@ -1,0 +1,23 @@
+{
+    "type":{
+        "name":"VByteArray",
+        "version":1
+    },
+    "value":[
+        0,
+        1,
+        2
+    ],
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VByteArray1a.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VByteArray1a.json
@@ -1,0 +1,30 @@
+{
+    "type":{
+        "name":"VByteArray",
+        "version":1
+    },
+    "value":[
+        0,
+        1,
+        2
+    ],
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0,
+        "userTag":null
+    },
+    "display":{
+        "lowAlarm":null,
+        "highAlarm":null,
+        "lowDisplay":null,
+        "highDisplay":null,
+        "lowWarning":null,
+        "highWarning":null,
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VDouble1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VDouble1.json
@@ -1,0 +1,19 @@
+{
+    "type":{
+        "name":"VDouble",
+        "version":1
+    },
+    "value":3.14,
+    "alarm":{
+        "severity":"MINOR",
+        "status":"DB",
+        "name":"LOW"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VDouble1a.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VDouble1a.json
@@ -1,0 +1,26 @@
+{  
+   "type":{  
+      "name":"VDouble",
+      "version":1
+   },
+   "value":3.14,
+   "alarm":{  
+      "severity":"MINOR",
+      "status":"DB",
+      "name":"LOW"
+   },
+   "time":{  
+      "unixSec":0,
+      "nanoSec":0,
+      "userTag":null
+   },
+   "display":{  
+      "lowAlarm":null,
+      "highAlarm":null,
+      "lowDisplay":null,
+      "highDisplay":null,
+      "lowWarning":null,
+      "highWarning":null,
+      "units":""
+   }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VDoubleArray1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VDoubleArray1.json
@@ -1,0 +1,23 @@
+{
+    "type":{
+        "name":"VDoubleArray",
+        "version":1
+    },
+    "value":[
+        0.0,
+        1.0,
+        2.0
+    ],
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VDoubleArray1a.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VDoubleArray1a.json
@@ -1,0 +1,30 @@
+{
+   "type":{
+      "name":"VDoubleArray",
+      "version":1
+   },
+   "value":[
+      0.0,
+      1.0,
+      2.0
+   ],
+   "alarm":{
+      "severity":"NONE",
+      "status":"NONE",
+      "name":"None"
+   },
+   "time":{
+      "unixSec":0,
+      "nanoSec":0,
+      "userTag":null
+   },
+   "display":{
+      "lowAlarm":null,
+      "highAlarm":null,
+      "lowDisplay":null,
+      "highDisplay":null,
+      "lowWarning":null,
+      "highWarning":null,
+      "units":""
+   }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VEnum1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VEnum1.json
@@ -1,0 +1,23 @@
+{
+    "type":{
+        "name":"VEnum",
+        "version":1
+    },
+    "value":1,
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "enum":{
+        "labels":[
+            "One",
+            "Two",
+            "Three"
+        ]
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VEnum1a.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VEnum1a.json
@@ -1,0 +1,24 @@
+{
+   "type":{
+      "name":"VEnum",
+      "version":1
+   },
+   "value":1,
+   "alarm":{
+      "severity":"NONE",
+      "status":"NONE",
+      "name":"None"
+   },
+   "time":{
+      "unixSec":0,
+      "nanoSec":0,
+      "userTag":null
+   },
+   "enum":{
+      "labels":[
+         "One",
+         "Two",
+         "Three"
+      ]
+   }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VFloat1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VFloat1.json
@@ -1,0 +1,19 @@
+{
+    "type":{
+        "name":"VFloat",
+        "version":1
+    },
+    "value":3.125,
+    "alarm":{
+        "severity":"MINOR",
+        "status":"DB",
+        "name":"HIGH"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VFloat1a.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VFloat1a.json
@@ -1,0 +1,26 @@
+{
+   "type":{
+      "name":"VFloat",
+      "version":1
+   },
+   "value":3.125,
+   "alarm":{
+      "severity":"MINOR",
+      "status":"DB",
+      "name":"HIGH"
+   },
+   "time":{
+      "unixSec":0,
+      "nanoSec":0,
+      "userTag":null
+   },
+   "display":{
+      "lowAlarm":null,
+      "highAlarm":null,
+      "lowDisplay":null,
+      "highDisplay":null,
+      "lowWarning":null,
+      "highWarning":null,
+      "units":""
+   }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VFloatArray1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VFloatArray1.json
@@ -1,0 +1,23 @@
+{
+    "type":{
+        "name":"VFloatArray",
+        "version":1
+    },
+    "value":[
+        0.0,
+        1.0,
+        2.0
+    ],
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VFloatArray1a.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VFloatArray1a.json
@@ -1,0 +1,23 @@
+{
+    "type":{
+        "name":"VFloatArray",
+        "version":1
+    },
+    "value":[
+        0.0,
+        1.0,
+        2.0
+    ],
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VInt1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VInt1.json
@@ -1,0 +1,19 @@
+{
+    "type":{
+        "name":"VInt",
+        "version":1
+    },
+    "value":314,
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VInt1a.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VInt1a.json
@@ -1,0 +1,26 @@
+{
+   "type":{
+      "name":"VInt",
+      "version":1
+   },
+   "value":314,
+   "alarm":{
+      "severity":"NONE",
+      "status":"NONE",
+      "name":"None"
+   },
+   "time":{
+      "unixSec":0,
+      "nanoSec":0,
+      "userTag":null
+   },
+   "display":{
+      "lowAlarm":null,
+      "highAlarm":null,
+      "lowDisplay":null,
+      "highDisplay":null,
+      "lowWarning":null,
+      "highWarning":null,
+      "units":""
+   }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VIntArray1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VIntArray1.json
@@ -1,0 +1,23 @@
+{
+    "type":{
+        "name":"VIntArray",
+        "version":1
+    },
+    "value":[
+        0,
+        1,
+        2
+    ],
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VLong1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VLong1.json
@@ -1,0 +1,19 @@
+{
+    "type":{
+        "name":"VLong",
+        "version":1
+    },
+    "value":313,
+    "alarm":{
+        "severity":"MINOR",
+        "status":"DB",
+        "name":"HIGH"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VLong1a.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VLong1a.json
@@ -1,0 +1,26 @@
+{
+   "type":{
+      "name":"VLong",
+      "version":1
+   },
+   "value":313,
+   "alarm":{
+      "severity":"MINOR",
+      "status":"DB",
+      "name":"HIGH"
+   },
+   "time":{
+      "unixSec":0,
+      "nanoSec":0,
+      "userTag":null
+   },
+   "display":{
+      "lowAlarm":null,
+      "highAlarm":null,
+      "lowDisplay":null,
+      "highDisplay":null,
+      "lowWarning":null,
+      "highWarning":null,
+      "units":""
+   }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VLongArray1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VLongArray1.json
@@ -1,0 +1,23 @@
+{
+    "type":{
+        "name":"VLongArray",
+        "version":1
+    },
+    "value":[
+        0,
+        1,
+        2
+    ],
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VShort1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VShort1.json
@@ -1,0 +1,19 @@
+{
+    "type":{
+        "name":"VShort",
+        "version":1
+    },
+    "value":314,
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VShort1a.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VShort1a.json
@@ -1,0 +1,26 @@
+{
+   "type":{
+      "name":"VShort",
+      "version":1
+   },
+   "value":314,
+   "alarm":{
+      "severity":"NONE",
+      "status":"NONE",
+      "name":"None"
+   },
+   "time":{
+      "unixSec":0,
+      "nanoSec":0,
+      "userTag":null
+   },
+   "display":{
+      "lowAlarm":null,
+      "highAlarm":null,
+      "lowDisplay":null,
+      "highDisplay":null,
+      "lowWarning":null,
+      "highWarning":null,
+      "units":""
+   }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VShortArray1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VShortArray1.json
@@ -1,0 +1,23 @@
+{
+    "type":{
+        "name":"VShortArray",
+        "version":1
+    },
+    "value":[
+        0,
+        1,
+        2
+    ],
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VString1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VString1.json
@@ -1,0 +1,16 @@
+{
+    "type":{
+        "name":"VString",
+        "version":1
+    },
+    "value":"Flower",
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VString1a.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VString1a.json
@@ -1,0 +1,17 @@
+{  
+   "type":{  
+      "name":"VString",
+      "version":1
+   },
+   "value":"Flower",
+   "alarm":{  
+      "severity":"NONE",
+      "status":"NONE",
+      "name":"None"
+   },
+   "time":{  
+      "unixSec":0,
+      "nanoSec":0,
+      "userTag":null
+   }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VUByte1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VUByte1.json
@@ -1,0 +1,19 @@
+{
+    "type":{
+        "name":"VUByte",
+        "version":1
+    },
+    "value":255,
+    "alarm":{
+        "severity":"MINOR",
+        "status":"DB",
+        "name":"HIGH"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VUByteArray1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VUByteArray1.json
@@ -1,0 +1,23 @@
+{
+    "type":{
+        "name":"VUByteArray",
+        "version":1
+    },
+    "value":[
+        255,
+        254,
+        253
+    ],
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VUInt1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VUInt1.json
@@ -1,0 +1,19 @@
+{
+    "type":{
+        "name":"VUInt",
+        "version":1
+    },
+    "value":4294967295,
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VUIntArray1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VUIntArray1.json
@@ -1,0 +1,23 @@
+{
+    "type":{
+        "name":"VUIntArray",
+        "version":1
+    },
+    "value":[
+        4294967295,
+        4294967294,
+        4294967293
+    ],
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VULong1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VULong1.json
@@ -1,0 +1,19 @@
+{
+    "type":{
+        "name":"VULong",
+        "version":1
+    },
+    "value":18446744073709551615,
+    "alarm":{
+        "severity":"MINOR",
+        "status":"DB",
+        "name":"HIGH"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VULongArray1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VULongArray1.json
@@ -1,0 +1,23 @@
+{
+    "type":{
+        "name":"VULongArray",
+        "version":1
+    },
+    "value":[
+        18446744073709551615,
+        18446744073709551614,
+        18446744073709551613
+    ],
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VUShort1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VUShort1.json
@@ -1,0 +1,19 @@
+{
+    "type":{
+        "name":"VUShort",
+        "version":1
+    },
+    "value":65535,
+    "alarm":{
+        "severity":"MINOR",
+        "status":"DB",
+        "name":"HIGH"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VUShortArray1.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VUShortArray1.json
@@ -1,0 +1,23 @@
+{
+    "type":{
+        "name":"VUShortArray",
+        "version":1
+    },
+    "value":[
+        65535,
+        65534,
+        65533
+    ],
+    "alarm":{
+        "severity":"NONE",
+        "status":"NONE",
+        "name":"None"
+    },
+    "time":{
+        "unixSec":0,
+        "nanoSec":0
+    },
+    "display":{
+        "units":""
+    }
+}


### PR DESCRIPTION
@shroffk @georgweiss 
Using Gson increases performance by ~30%.
Testing with 24k PVs takes ~9s while the previous takes ~12s.

As always, this is not effective until you replace the Jackson provider in Jersey client setting.
Currently, I tested this with the test code and Phoebus save&restore "client". Both worked fine.
However, service still uses Jackson provider to de/serialize Json/VType, the speed of which doesn't seem to change much as in client side.