### PR TITLE
#117 Check Status.getStackDump() is non-empty before use

### DIFF
--- a/pvAccessJava/src/org/epics/pvaccess/client/rpc/RPCClientImpl.java
+++ b/pvAccessJava/src/org/epics/pvaccess/client/rpc/RPCClientImpl.java
@@ -129,10 +129,11 @@ public class RPCClientImpl implements RPCClient, ChannelRequester, ChannelRPCReq
 					return result;
 				else
 				{
-					if (status.getStackDump() == null)
-						throw new RPCRequestException(status.getType(), status.getMessage());
+					String stackDump = status.getStackDump();
+					if (stackDump != null && !stackDump.isEmpty())
+						throw new RPCRequestException(status.getType(), status.getMessage() + ", cause:\n" + stackDump);
 					else
-						throw new RPCRequestException(status.getType(), status.getMessage() + ", cause:\n" + status.getStackDump());
+						throw new RPCRequestException(status.getType(), status.getMessage());
 				}
 			}
 			else

--- a/pvAccessJava/src/org/epics/pvaccess/server/impl/remote/rpc/ServerRPCService.java
+++ b/pvAccessJava/src/org/epics/pvaccess/server/impl/remote/rpc/ServerRPCService.java
@@ -288,8 +288,9 @@ public class ServerRPCService implements RPCService {
 			if (!status.isSuccess())
 			{
 				String errorMessage = "failed to fetch channel list: " + status.getMessage();
-				if (status.getStackDump() != null)
-					errorMessage += "\n" + status.getStackDump();
+				String stackDump = status.getStackDump();
+				if (stackDump != null && !stackDump.isEmpty())
+					errorMessage += "\n" + stackDump;
 				throw new RPCRequestException(StatusType.ERROR, errorMessage);
 			}
 			


### PR DESCRIPTION
This check is already used in methods such as
BlockingServerTCPTransport#authenticationCompleted.