### PR TITLE
VImage: Add x&yoffset as well as 'reversed' flags to image meta data

### DIFF
--- a/epics-vtype/vtype/src/main/java/org/epics/vtype/IVImage.java
+++ b/epics-vtype/vtype/src/main/java/org/epics/vtype/IVImage.java
@@ -17,16 +17,19 @@ public class IVImage extends VImage {
     private final int width;
     private final int xoffset;
     private final int yoffset;
+    private final boolean xreversed;
+    private final boolean yreversed;
     private final ListNumber data;
     private final VImageDataType imageDataType;
     private final VImageType imageType;
 
     IVImage(int height, int width, ListNumber data, VImageDataType imageDataType, VImageType imageType, Alarm alarm,
             Time time) {
-        this(height, width, 0, 0, data, imageDataType, imageType, alarm, time);
+        this(height, width, 0, 0, false, false, data, imageDataType, imageType, alarm, time);
     }
 
-    IVImage(int height, int width, int xoffset, int yoffset, ListNumber data, VImageDataType imageDataType, VImageType imageType, Alarm alarm,
+    IVImage(int height, int width, int xoffset, int yoffset, boolean xreversed, boolean yreversed,
+            ListNumber data, VImageDataType imageDataType, VImageType imageType, Alarm alarm,
             Time time) {
         VType.argumentNotNull("alarm", alarm);
         VType.argumentNotNull("time", time);
@@ -36,6 +39,8 @@ public class IVImage extends VImage {
         this.width = width;
         this.xoffset = xoffset;
         this.yoffset = yoffset;
+        this.xreversed = xreversed;
+        this.yreversed = yreversed;
         this.data = data;
         this.imageDataType = imageDataType;
         this.imageType = imageType;
@@ -55,6 +60,14 @@ public class IVImage extends VImage {
 
     public int getYOffset() {
         return yoffset;
+    }
+
+    public boolean isXReversed() {
+        return xreversed;
+    }
+
+    public boolean isYReversed() {
+        return yreversed;
     }
 
     public ListNumber getData() {

--- a/epics-vtype/vtype/src/main/java/org/epics/vtype/IVImage.java
+++ b/epics-vtype/vtype/src/main/java/org/epics/vtype/IVImage.java
@@ -15,19 +15,27 @@ public class IVImage extends VImage {
 
     private final int height;
     private final int width;
+    private final int xoffset;
+    private final int yoffset;
     private final ListNumber data;
     private final VImageDataType imageDataType;
     private final VImageType imageType;
 
     IVImage(int height, int width, ListNumber data, VImageDataType imageDataType, VImageType imageType, Alarm alarm,
             Time time) {
-        super();
+        this(height, width, 0, 0, data, imageDataType, imageType, alarm, time);
+    }
+
+    IVImage(int height, int width, int xoffset, int yoffset, ListNumber data, VImageDataType imageDataType, VImageType imageType, Alarm alarm,
+            Time time) {
         VType.argumentNotNull("alarm", alarm);
         VType.argumentNotNull("time", time);
         this.alarm = alarm;
         this.time = time;
         this.height = height;
         this.width = width;
+        this.xoffset = xoffset;
+        this.yoffset = yoffset;
         this.data = data;
         this.imageDataType = imageDataType;
         this.imageType = imageType;
@@ -39,6 +47,14 @@ public class IVImage extends VImage {
 
     public int getWidth() {
         return width;
+    }
+
+    public int getXOffset() {
+        return xoffset;
+    }
+
+    public int getYOffset() {
+        return yoffset;
     }
 
     public ListNumber getData() {

--- a/epics-vtype/vtype/src/main/java/org/epics/vtype/VImage.java
+++ b/epics-vtype/vtype/src/main/java/org/epics/vtype/VImage.java
@@ -50,6 +50,22 @@ public abstract class VImage extends VType implements AlarmProvider, TimeProvide
     public abstract int getYOffset();
 
     /**
+     * Is the horizontal axis reversed?
+     * Defaults to false.
+     *
+     * @return <code>true</code> if axis is reversed
+     */
+    public abstract boolean isXReversed();
+
+    /**
+     * Is the vertical axis reversed?
+     * Defaults to false.
+     *
+     * @return <code>true</code> if axis is reversed
+     */
+    public abstract boolean isYReversed();
+
+    /**
      * Image data;
      *
      * @return ListNumber image data
@@ -85,7 +101,7 @@ public abstract class VImage extends VType implements AlarmProvider, TimeProvide
      * @return a new instance of VImage
      */
     public static VImage of(int height, int width, final ListNumber data, VImageDataType imageDataType, VImageType vImageType, Alarm alarm, Time time) {
-        return of(height, width, 0, 0, data, imageDataType, vImageType, alarm, time);
+        return of(height, width, 0, 0, false, false, data, imageDataType, vImageType, alarm, time);
     }
 
     /**
@@ -95,6 +111,8 @@ public abstract class VImage extends VType implements AlarmProvider, TimeProvide
      * @param width image width
      * @param xoffset horizontal offset
      * @param yoffset vertical offset
+     * @param xreversed is horizontal axis reversed?
+     * @param yreversed is vertical axis reversed?
      * @param data image data
      * @param imageDataType image data type
      * @param vImageType image type
@@ -102,8 +120,9 @@ public abstract class VImage extends VType implements AlarmProvider, TimeProvide
      * @param time timestamp
      * @return a new instance of VImage
      */
-    public static VImage of(int height, int width, int xoffset, int yoffset, final ListNumber data, VImageDataType imageDataType, VImageType vImageType, Alarm alarm, Time time) {
-        return new IVImage(height, width, xoffset, yoffset, data, imageDataType, vImageType, alarm, time);
+    public static VImage of(int height, int width, int xoffset, int yoffset, boolean xreversed, boolean yreversed,
+                            final ListNumber data, VImageDataType imageDataType, VImageType vImageType, Alarm alarm, Time time) {
+        return new IVImage(height, width, xoffset, yoffset, xreversed, yreversed, data, imageDataType, vImageType, alarm, time);
     }
 
     @Override

--- a/epics-vtype/vtype/src/main/java/org/epics/vtype/VImage.java
+++ b/epics-vtype/vtype/src/main/java/org/epics/vtype/VImage.java
@@ -30,6 +30,26 @@ public abstract class VImage extends VType implements AlarmProvider, TimeProvide
     public abstract int getWidth();
 
     /**
+     * Horizontal pixel offset.
+     * For sub-images within a larger image,
+     * this is the X offset.
+     * Defaults to zero.
+     *
+     * @return pixel offset
+     */
+    public abstract int getXOffset();
+
+    /**
+     * Vertical pixel offset.
+     * For sub-images within a larger image,
+     * this is the Y offset.
+     * Defaults to zero.
+     *
+     * @return pixel offset
+     */
+    public abstract int getYOffset();
+
+    /**
      * Image data;
      *
      * @return ListNumber image data
@@ -65,7 +85,25 @@ public abstract class VImage extends VType implements AlarmProvider, TimeProvide
      * @return a new instance of VImage
      */
     public static VImage of(int height, int width, final ListNumber data, VImageDataType imageDataType, VImageType vImageType, Alarm alarm, Time time) {
-        return new IVImage(height, width, data, imageDataType, vImageType, alarm, time);
+        return of(height, width, 0, 0, data, imageDataType, vImageType, alarm, time);
+    }
+
+    /**
+     * Creates a new VImage.
+     *
+     * @param height image height
+     * @param width image width
+     * @param xoffset horizontal offset
+     * @param yoffset vertical offset
+     * @param data image data
+     * @param imageDataType image data type
+     * @param vImageType image type
+     * @param alarm alarm information
+     * @param time timestamp
+     * @return a new instance of VImage
+     */
+    public static VImage of(int height, int width, int xoffset, int yoffset, final ListNumber data, VImageDataType imageDataType, VImageType vImageType, Alarm alarm, Time time) {
+        return new IVImage(height, width, xoffset, yoffset, data, imageDataType, vImageType, alarm, time);
     }
 
     @Override
@@ -80,6 +118,8 @@ public abstract class VImage extends VType implements AlarmProvider, TimeProvide
             return getClass().equals(other.getClass()) 
                     && getHeight() == other.getHeight()
                     && getWidth() == other.getWidth()
+                    && getXOffset() == other.getXOffset()
+                    && getYOffset() == other.getYOffset()
                     && getData().equals(other.getData())
                     && getDataType().equals(other.getDataType())
                     && getVImageType().equals(other.getVImageType())
@@ -95,6 +135,8 @@ public abstract class VImage extends VType implements AlarmProvider, TimeProvide
         int hash = 7;
         hash = 23 * hash + Objects.hashCode(getHeight());
         hash = 23 * hash + Objects.hashCode(getWidth());
+        hash = 23 * hash + Objects.hashCode(getXOffset());
+        hash = 23 * hash + Objects.hashCode(getYOffset());
         hash = 23 * hash + Objects.hashCode(getData());
         hash = 23 * hash + Objects.hashCode(getDataType());
         hash = 23 * hash + Objects.hashCode(getVImageType());

--- a/pvAccessJava/src/org/epics/pvaccess/client/rpc/package.html
+++ b/pvAccessJava/src/org/epics/pvaccess/client/rpc/package.html
@@ -8,11 +8,11 @@
 </head>
 
 <body>
-<h1>Support code for implementing channelRPC.</h1>
+<h2>Support code for implementing channelRPC.</h2>
 
-<h1 style="text-align: center">PVService<br>
+<h2 style="text-align: center">PVService<br>
 This page documentation needs to be updated!<br>
-2011.08.22</h1>
+2011.08.22</h2>
 CONTENTS 
 
 <div class="toc">


### PR DESCRIPTION
Allows CSS to populate that info from pva://.. image PVs (NTNDArray) and then use that with a "limits_from_pv" option to automatically update axes of image widget. Formula function allow access to the info from rules/scripts. See https://github.com/ControlSystemStudio/phoebus/tree/image_offset