### PR TITLE
Support for DESC field in Display

### DIFF
--- a/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonVTypeBuilder.java
+++ b/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonVTypeBuilder.java
@@ -163,6 +163,7 @@ class GsonVTypeBuilder extends JsonElement {
                 .addIgnoreNaN("lowWarning", display.getWarningRange().getMinimum())
                 .addIgnoreNaN("highWarning", display.getWarningRange().getMaximum())
                 .add("units", display.getUnit())
+                .addNullableObject("description", display.getDescription())
                 .build());
     }
     
@@ -242,6 +243,8 @@ class GsonVTypeBuilder extends JsonElement {
             addListNumber(string, (ListNumber) o);
         } else if (o instanceof ListBoolean) {
             addListBoolean(string, (ListBoolean) o);
+        } else if (o instanceof String) {
+            add(string, (String)o);
         } else {
             throw new UnsupportedOperationException("Class " + o.getClass() + " not supported");
         }

--- a/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/VTypeGsonMapper.java
+++ b/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/VTypeGsonMapper.java
@@ -116,7 +116,8 @@ class VTypeGsonMapper extends JsonElement {
                 Range.of(display.getNotNullDouble("lowAlarm"), display.getNotNullDouble("highAlarm")),
                 Range.of(display.getNotNullDouble("lowWarning"), display.getNotNullDouble("highWarning")),
                 Range.of(display.getNotNullDouble("lowControl"), display.getNotNullDouble("highControl")),
-                display.getString("units"), new DecimalFormat());
+                display.getString("units"), new DecimalFormat(),
+                display.getString("description", null));
     }
     
     public ListDouble getListDouble(String string) {
@@ -280,7 +281,7 @@ class VTypeGsonMapper extends JsonElement {
     }
 
     public String getString(String string, String string1) {
-        return json.get(string).isJsonNull() ? string1 : json.get(string).getAsString();
+        return (json.get(string) == null || json.get(string).isJsonNull()) ? string1 : json.get(string).getAsString();
     }
 
     public int getInt(String string) {

--- a/epics-vtype/vtype-gson/src/test/java/org/epics/vtype/gson/VTypeToGsonTest.java
+++ b/epics-vtype/vtype-gson/src/test/java/org/epics/vtype/gson/VTypeToGsonTest.java
@@ -9,6 +9,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,6 +34,7 @@ import org.epics.util.number.UByte;
 import org.epics.util.number.UInteger;
 import org.epics.util.number.ULong;
 import org.epics.util.number.UShort;
+import org.epics.util.stats.Range;
 import org.epics.vtype.Alarm;
 import org.epics.vtype.AlarmSeverity;
 import org.epics.vtype.AlarmStatus;
@@ -129,6 +132,35 @@ public class VTypeToGsonTest {
 
     @Test
     public void vDouble1() {
+        VDouble vDouble1 = VDouble.of(3.14, Alarm.of(AlarmSeverity.MINOR, AlarmStatus.DB, "LOW"), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
+        testSerialization(vDouble1, "VDouble1");
+        testDeserialization("VDouble1", vDouble1);
+        testDeserialization("VDouble1a", vDouble1);
+    }
+
+    @Test
+    public void vDouble1b() {
+        VDouble vDouble1 = VDouble.of(3.14, Alarm.of(AlarmSeverity.MINOR,
+                AlarmStatus.DB, "LOW"),
+                Time.of(Instant.ofEpochSecond(0, 0)),
+                Display.of(Range.of(-100.0, 100.0), Range.of(-100.0, 100.0), Range.of(-10.0, 10.0), Range.of(Double.NaN, Double.NaN), "degC", new DecimalFormat(), null));
+        testSerialization(vDouble1, "VDouble1b");
+        testDeserialization("VDouble1b", vDouble1);
+    }
+
+    @Test
+    public void vDouble1c() {
+        VDouble vDouble1 = VDouble.of(3.14, Alarm.of(AlarmSeverity.MINOR,
+                        AlarmStatus.DB, "LOW"),
+                Time.of(Instant.ofEpochSecond(0, 0)),
+                Display.of(Range.of(-100.0, 100.0), Range.of(-100.0, 100.0), Range.of(-10.0, 10.0), Range.of(Double.NaN, Double.NaN), "degC", new DecimalFormat(), "fooBar"));
+        testSerialization(vDouble1, "VDouble1c");
+        testDeserialization("VDouble1c", vDouble1);
+    }
+
+
+    @Test
+    public void vDouble2() {
         VDouble vDouble1 = VDouble.of(3.14, Alarm.of(AlarmSeverity.MINOR, AlarmStatus.DB, "LOW"), Time.of(Instant.ofEpochSecond(0, 0)), Display.none());
         testSerialization(vDouble1, "VDouble1");
         testDeserialization("VDouble1", vDouble1);

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VDouble1b.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VDouble1b.json
@@ -1,0 +1,25 @@
+{  
+   "type":{  
+      "name":"VDouble",
+      "version":1
+   },
+   "value":3.14,
+   "alarm":{  
+      "severity":"MINOR",
+      "status":"DB",
+      "name":"LOW"
+   },
+   "time":{  
+      "unixSec":0,
+      "nanoSec":0
+   },
+   "display":{  
+      "lowAlarm":-100.0,
+      "highAlarm":100.0,
+      "lowDisplay":-100.0,
+      "highDisplay":100.0,
+      "lowWarning":-10.0,
+      "highWarning":10.0,
+      "units":"degC"
+   }
+}

--- a/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VDouble1c.json
+++ b/epics-vtype/vtype-gson/src/test/resources/org/epics/vtype/gson/VDouble1c.json
@@ -1,0 +1,26 @@
+{  
+   "type":{  
+      "name":"VDouble",
+      "version":1
+   },
+   "value":3.14,
+   "alarm":{  
+      "severity":"MINOR",
+      "status":"DB",
+      "name":"LOW"
+   },
+   "time":{  
+      "unixSec":0,
+      "nanoSec":0
+   },
+   "display":{
+      "lowAlarm":-100.0,
+      "highAlarm":100.0,
+      "lowDisplay":-100.0,
+      "highDisplay":100.0,
+      "lowWarning":-10.0,
+      "highWarning":10.0,
+      "units":"degC",
+      "description": "fooBar"
+   }
+}

--- a/epics-vtype/vtype-json/src/main/java/org/epics/vtype/json/JsonVTypeBuilder.java
+++ b/epics-vtype/vtype-json/src/main/java/org/epics/vtype/json/JsonVTypeBuilder.java
@@ -147,7 +147,8 @@ class JsonVTypeBuilder implements JsonObjectBuilder {
                 .addIgnoreNaN("highDisplay", display.getDisplayRange().getMaximum())
                 .addIgnoreNaN("lowWarning", display.getWarningRange().getMinimum())
                 .addIgnoreNaN("highWarning", display.getWarningRange().getMaximum())
-                .add("units", display.getUnit()));
+                .add("units", display.getUnit())
+                .addNullableObject("description", display.getDescription()));
     }
     
     public JsonVTypeBuilder addEnum(VEnum en) {
@@ -225,6 +226,8 @@ class JsonVTypeBuilder implements JsonObjectBuilder {
             addListNumber(string, (ListNumber) o);
         } else if (o instanceof ListBoolean) {
             addListBoolean(string, (ListBoolean) o);
+        } else if (o instanceof String){
+            add(string, (String)o);
         } else {
             throw new UnsupportedOperationException("Class " + o.getClass() + " not supported");
         }

--- a/epics-vtype/vtype-json/src/main/java/org/epics/vtype/json/VTypeJsonMapper.java
+++ b/epics-vtype/vtype-json/src/main/java/org/epics/vtype/json/VTypeJsonMapper.java
@@ -100,7 +100,8 @@ class VTypeJsonMapper implements JsonObject {
                 Range.of(display.getNotNullDouble("lowAlarm"), display.getNotNullDouble("highAlarm")),
                 Range.of(display.getNotNullDouble("lowWarning"), display.getNotNullDouble("highWarning")),
                 Range.of(display.getNotNullDouble("lowControl"), display.getNotNullDouble("highControl")),
-                display.getString("units"), new DecimalFormat());
+                display.getString("units"), new DecimalFormat(),
+                display.getString("description", null));
     }
     
     public ListDouble getListDouble(String string) {

--- a/epics-vtype/vtype-json/src/test/java/org/epics/vtype/json/VTypeToJsonTest.java
+++ b/epics-vtype/vtype-json/src/test/java/org/epics/vtype/json/VTypeToJsonTest.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.text.DecimalFormat;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,6 +33,7 @@ import org.epics.util.number.UByte;
 import org.epics.util.number.UInteger;
 import org.epics.util.number.ULong;
 import org.epics.util.number.UShort;
+import org.epics.util.stats.Range;
 import org.epics.vtype.Alarm;
 import org.epics.vtype.AlarmSeverity;
 import org.epics.vtype.AlarmStatus;
@@ -133,6 +135,26 @@ public class VTypeToJsonTest {
         testSerialization(vDouble1, "VDouble1");
         testDeserialization("VDouble1", vDouble1);
         testDeserialization("VDouble1a", vDouble1);
+    }
+
+    @Test
+    public void vDouble1b() {
+        VDouble vDouble1 = VDouble.of(3.14, Alarm.of(AlarmSeverity.MINOR,
+                        AlarmStatus.DB, "LOW"),
+                Time.of(Instant.ofEpochSecond(0, 0)),
+                Display.of(Range.of(-100.0, 100.0), Range.of(-100.0, 100.0), Range.of(-10.0, 10.0), Range.of(Double.NaN, Double.NaN), "degC", new DecimalFormat(), null));
+        testSerialization(vDouble1, "VDouble1b");
+        testDeserialization("VDouble1b", vDouble1);
+    }
+
+    @Test
+    public void vDouble1c() {
+        VDouble vDouble1 = VDouble.of(3.14, Alarm.of(AlarmSeverity.MINOR,
+                        AlarmStatus.DB, "LOW"),
+                Time.of(Instant.ofEpochSecond(0, 0)),
+                Display.of(Range.of(-100.0, 100.0), Range.of(-100.0, 100.0), Range.of(-10.0, 10.0), Range.of(Double.NaN, Double.NaN), "degC", new DecimalFormat(), "fooBar"));
+        testSerialization(vDouble1, "VDouble1c");
+        testDeserialization("VDouble1c", vDouble1);
     }
     
     @Test

--- a/epics-vtype/vtype-json/src/test/resources/org/epics/vtype/json/VDouble1b.json
+++ b/epics-vtype/vtype-json/src/test/resources/org/epics/vtype/json/VDouble1b.json
@@ -1,0 +1,25 @@
+{  
+   "type":{  
+      "name":"VDouble",
+      "version":1
+   },
+   "value":3.14,
+   "alarm":{  
+      "severity":"MINOR",
+      "status":"DB",
+      "name":"LOW"
+   },
+   "time":{  
+      "unixSec":0,
+      "nanoSec":0
+   },
+   "display":{  
+      "lowAlarm":-100.0,
+      "highAlarm":100.0,
+      "lowDisplay":-100.0,
+      "highDisplay":100.0,
+      "lowWarning":-10.0,
+      "highWarning":10.0,
+      "units":"degC"
+   }
+}

--- a/epics-vtype/vtype-json/src/test/resources/org/epics/vtype/json/VDouble1c.json
+++ b/epics-vtype/vtype-json/src/test/resources/org/epics/vtype/json/VDouble1c.json
@@ -1,0 +1,26 @@
+{  
+   "type":{  
+      "name":"VDouble",
+      "version":1
+   },
+   "value":3.14,
+   "alarm":{  
+      "severity":"MINOR",
+      "status":"DB",
+      "name":"LOW"
+   },
+   "time":{  
+      "unixSec":0,
+      "nanoSec":0
+   },
+   "display":{
+      "lowAlarm":-100.0,
+      "highAlarm":100.0,
+      "lowDisplay":-100.0,
+      "highDisplay":100.0,
+      "lowWarning":-10.0,
+      "highWarning":10.0,
+      "units":"degC",
+      "description": "fooBar"
+   }
+}

--- a/epics-vtype/vtype/src/main/java/org/epics/vtype/Display.java
+++ b/epics-vtype/vtype/src/main/java/org/epics/vtype/Display.java
@@ -67,8 +67,7 @@ public abstract class Display {
 
     /**
      * Human-readable description of the underlying data, e.g. the DESC field of an EPICS record.
-     * <code>null</code> if not set.
-     * @return unit
+     * @return description, or <code>null</code> if not set.
      */
     public abstract String getDescription();
     

--- a/epics-vtype/vtype/src/main/java/org/epics/vtype/Display.java
+++ b/epics-vtype/vtype/src/main/java/org/epics/vtype/Display.java
@@ -64,6 +64,13 @@ public abstract class Display {
      * @return the default format for all values
      */
     public abstract NumberFormat getFormat();
+
+    /**
+     * Human-readable description of the underlying data, e.g. the DESC field of an EPICS record.
+     * <code>null</code> if not set.
+     * @return unit
+     */
+    public abstract String getDescription();
     
         
     /**
@@ -97,7 +104,7 @@ public abstract class Display {
             return true;
         }
         
-	if (obj instanceof Display) {
+	    if (obj instanceof Display) {
             Display other = (Display) obj;
         
             return Objects.equals(getFormat(), other.getFormat()) &&
@@ -105,7 +112,8 @@ public abstract class Display {
                 Objects.equals(getDisplayRange(), other.getDisplayRange()) &&
                 Objects.equals(getAlarmRange(), other.getAlarmRange()) &&
                 Objects.equals(getWarningRange(), other.getWarningRange()) &&
-                Objects.equals(getControlRange(), other.getControlRange());
+                Objects.equals(getControlRange(), other.getControlRange()) &&
+                Objects.equals(getDescription(), other.getDescription());
         }
         
         return false;
@@ -120,12 +128,20 @@ public abstract class Display {
         hash = 59 * hash + Objects.hashCode(getAlarmRange());
         hash = 59 * hash + Objects.hashCode(getWarningRange());
         hash = 59 * hash + Objects.hashCode(getControlRange());
+        hash = 59 * hash + Objects.hashCode(getDescription());
         return hash;
     }
 
     @Override
     public final String toString() {
-        return "Display[units: " + getUnit() + " disp: " + getDisplayRange() + " alarm: " + getAlarmRange() + " warn: " + getWarningRange() + " ctrl: " + getControlRange() + " format: " + getFormat() + "]";
+        return "Display[units: " + getUnit() +
+                " disp: " + getDisplayRange() +
+                " alarm: " + getAlarmRange() +
+                " warn: " + getWarningRange() +
+                " ctrl: " + getControlRange() +
+                " format: " + getFormat() +
+                " description: " + getDescription() +
+                "]";
     }
     
     /**
@@ -141,8 +157,26 @@ public abstract class Display {
      */
     public static Display of(final Range displayRange, final Range alarmRange, final Range warningRange,
             final Range controlRange, final String units, final NumberFormat numberFormat) {
+        return of(displayRange, alarmRange, warningRange,
+                controlRange, units, numberFormat, null);
+    }
+
+    /**
+     * Creates a new display.
+     *
+     * @param displayRange the display range
+     * @param warningRange the warning range
+     * @param alarmRange the alarm range
+     * @param controlRange the control range
+     * @param units the units
+     * @param numberFormat the preferred number format
+     * @param description a human-readable description of the underlying data.
+     * @return a new display
+     */
+    public static Display of(final Range displayRange, final Range alarmRange, final Range warningRange,
+                             final Range controlRange, final String units, final NumberFormat numberFormat, String description) {
         return new IDisplay(displayRange, alarmRange, warningRange,
-                controlRange, units, numberFormat);
+                controlRange, units, numberFormat, description);
     }
     
     // TODO: maybe this can be configured (injected through SPI?)
@@ -150,7 +184,7 @@ public abstract class Display {
     
     private static final Display DISPLAY_NONE = of(Range.undefined(),
             Range.undefined(), Range.undefined(), Range.undefined(), 
-            defaultUnits(), DEFAULT_NUMBERFORMAT);
+            defaultUnits(), DEFAULT_NUMBERFORMAT, null);
 
     /**
      * The default number format for number display.

--- a/epics-vtype/vtype/src/main/java/org/epics/vtype/IDisplay.java
+++ b/epics-vtype/vtype/src/main/java/org/epics/vtype/IDisplay.java
@@ -20,6 +20,7 @@ final class IDisplay extends Display {
     private final Range controlRange;
     private final String unit;
     private final NumberFormat format;
+    private final String description;
 
     public IDisplay(Range displayRange, Range alarmRange, Range warningRange,
             Range controlRange, String unit, NumberFormat format) {
@@ -35,6 +36,24 @@ final class IDisplay extends Display {
         this.controlRange = controlRange;
         this.unit = unit;
         this.format = format;
+        this.description = null;
+    }
+
+    public IDisplay(Range displayRange, Range alarmRange, Range warningRange,
+                    Range controlRange, String unit, NumberFormat format, String description) {
+        VType.argumentNotNull("displayRange", displayRange);
+        VType.argumentNotNull("warningRange", warningRange);
+        VType.argumentNotNull("alarmRange", alarmRange);
+        VType.argumentNotNull("controlRange", controlRange);
+        VType.argumentNotNull("unit", unit);
+        VType.argumentNotNull("format", format);
+        this.displayRange = displayRange;
+        this.warningRange = warningRange;
+        this.alarmRange = alarmRange;
+        this.controlRange = controlRange;
+        this.unit = unit;
+        this.format = format;
+        this.description = description;
     }
 
     @Override
@@ -65,6 +84,11 @@ final class IDisplay extends Display {
     @Override
     public NumberFormat getFormat() {
         return format;
+    }
+
+    @Override
+    public String getDescription(){
+        return description;
     }
 
 }

--- a/epics-vtype/vtype/src/test/java/org/epics/vtype/DisplayTest.java
+++ b/epics-vtype/vtype/src/test/java/org/epics/vtype/DisplayTest.java
@@ -101,42 +101,42 @@ public class DisplayTest {
         assertThat(display.getControlRange(), equalTo(Range.of(0.0, 10.0)));
         assertThat(display.getUnit(), equalTo("m"));
         assertThat(display.getFormat(), equalTo(format));
+        assertNull(display.getDescription());
     }
 
     @Test(expected=NullPointerException.class)
     public void of2() {
         NumberFormat format = new DecimalFormat();
-        Display display = Display.of(null, Range.of(2, 8), Range.of(1, 9), Range.of(0, 10), "m", format);
+        Display.of(null, Range.of(2, 8), Range.of(1, 9), Range.of(0, 10), "m", format);
     }
 
     @Test(expected=NullPointerException.class)
     public void of3() {
         NumberFormat format = new DecimalFormat();
-        Display display = Display.of(Range.of(0, 10), Range.of(2, 8), null, Range.of(0, 10), "m", format);
+        Display.of(Range.of(0, 10), Range.of(2, 8), null, Range.of(0, 10), "m", format);
     }
 
     @Test(expected=NullPointerException.class)
     public void of4() {
         NumberFormat format = new DecimalFormat();
-        Display display = Display.of(Range.of(0, 10), null, Range.of(1, 9), Range.of(0, 10), "m", format);
+        Display.of(Range.of(0, 10), null, Range.of(1, 9), Range.of(0, 10), "m", format);
     }
 
     @Test(expected=NullPointerException.class)
     public void of5() {
         NumberFormat format = new DecimalFormat();
-        Display display = Display.of(Range.of(0, 10), Range.of(2, 8), Range.of(1, 9), null, "m", format);
+        Display.of(Range.of(0, 10), Range.of(2, 8), Range.of(1, 9), null, "m", format);
     }
 
     @Test(expected=NullPointerException.class)
     public void of6() {
         NumberFormat format = new DecimalFormat();
-        Display display = Display.of(Range.of(0, 10), Range.of(2, 8), Range.of(1, 9), Range.of(0, 10), null, format);
+        Display.of(Range.of(0, 10), Range.of(2, 8), Range.of(1, 9), Range.of(0, 10), null, format);
     }
 
     @Test(expected=NullPointerException.class)
     public void of7() {
-        NumberFormat format = new DecimalFormat();
-        Display display = Display.of(Range.of(0, 10), Range.of(2, 8), Range.of(1, 9), Range.of(0, 10), "m", null);
+        Display.of(Range.of(0, 10), Range.of(2, 8), Range.of(1, 9), Range.of(0, 10), "m", null);
     }
     
     @Test
@@ -147,6 +147,7 @@ public class DisplayTest {
         assertThat(display.getAlarmRange(), equalTo(Range.undefined()));
         assertThat(display.getControlRange(), equalTo(Range.undefined()));
         assertThat(display.getUnit(), equalTo(""));
+        assertNull(display.getDescription());
     }
     
     @Test
@@ -203,5 +204,15 @@ public class DisplayTest {
         assertThat(display.newAlarmFor(-8.5), equalTo(Alarm.none()));
         assertThat(display.newAlarmFor(-9.5), equalTo(Alarm.lolo()));
     }
-   
+
+    @Test
+    public void testDescription(){
+        Display display = Display.of(Range.of(-10, 10), Range.of(-9, 9), Range.undefined(), Range.undefined(),
+                "", Display.defaultNumberFormat());
+        assertNull(display.getDescription());
+
+        display = Display.of(Range.of(-10, 10), Range.of(-9, 9), Range.undefined(), Range.undefined(),
+                "", Display.defaultNumberFormat(), "desc");
+        assertEquals("desc", display.getDescription());
+    }
 }


### PR DESCRIPTION
Added a "description" field in the Display class in order to support access to the DESC field of an EPICS record.

Changes should be backwards compatible, i.e. client code need not set the Display#description. If not set, the value is null.