### PR TITLE
JSON conversion to handle infinity

### DIFF
--- a/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonVTypeBuilder.java
+++ b/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/GsonVTypeBuilder.java
@@ -107,8 +107,8 @@ class GsonVTypeBuilder extends JsonElement {
         return this;
     }
 
-    public GsonVTypeBuilder addIgnoreNaN(String string, double d) {
-        if (!Double.isNaN(d)) {
+    public GsonVTypeBuilder addIgnoreNaNAndInfinity(String string, double d) {
+        if (!Double.isNaN(d) && !Double.isInfinite(d)) {
             jsonObject.addProperty(string, d);
         }
         return this;
@@ -156,12 +156,12 @@ class GsonVTypeBuilder extends JsonElement {
     
     public GsonVTypeBuilder addDisplay(Display display) {
         return add("display", new GsonVTypeBuilder()
-                .addIgnoreNaN("lowAlarm", display.getAlarmRange().getMinimum())
-                .addIgnoreNaN("highAlarm", display.getAlarmRange().getMaximum())
-                .addIgnoreNaN("lowDisplay", display.getDisplayRange().getMinimum())
-                .addIgnoreNaN("highDisplay", display.getDisplayRange().getMaximum())
-                .addIgnoreNaN("lowWarning", display.getWarningRange().getMinimum())
-                .addIgnoreNaN("highWarning", display.getWarningRange().getMaximum())
+                .addIgnoreNaNAndInfinity("lowAlarm", display.getAlarmRange().getMinimum())
+                .addIgnoreNaNAndInfinity("highAlarm", display.getAlarmRange().getMaximum())
+                .addIgnoreNaNAndInfinity("lowDisplay", display.getDisplayRange().getMinimum())
+                .addIgnoreNaNAndInfinity("highDisplay", display.getDisplayRange().getMaximum())
+                .addIgnoreNaNAndInfinity("lowWarning", display.getWarningRange().getMinimum())
+                .addIgnoreNaNAndInfinity("highWarning", display.getWarningRange().getMaximum())
                 .add("units", display.getUnit())
                 .addNullableObject("description", display.getDescription())
                 .build());

--- a/epics-vtype/vtype-gson/src/test/java/org/epics/vtype/gson/GsonVTypeBuilderTest.java
+++ b/epics-vtype/vtype-gson/src/test/java/org/epics/vtype/gson/GsonVTypeBuilderTest.java
@@ -1,0 +1,34 @@
+package org.epics.vtype.gson;
+
+import com.google.gson.JsonObject;
+import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class GsonVTypeBuilderTest {
+
+    @Test
+    public void testAddIgnoreNanAndInfinity(){
+        GsonVTypeBuilder gsonVTypeBuilder = new GsonVTypeBuilder();
+        gsonVTypeBuilder.addIgnoreNaNAndInfinity("thisIsOk", 7.7);
+        JsonObject jsonObject = gsonVTypeBuilder.build();
+        assertNotNull(jsonObject.get("thisIsOk"));
+
+        gsonVTypeBuilder.addIgnoreNaNAndInfinity("thisIsOkToo", 42);
+        jsonObject = gsonVTypeBuilder.build();
+        assertNotNull(jsonObject.get("thisIsOkToo"));
+        assertNotNull(jsonObject.get("thisIsOk"));
+
+        gsonVTypeBuilder.addIgnoreNaNAndInfinity("NaN", Double.NaN);
+        gsonVTypeBuilder.build();
+        assertNull(jsonObject.get("NaN"));
+
+        gsonVTypeBuilder.addIgnoreNaNAndInfinity("NegativeInfinity", Double.NEGATIVE_INFINITY);
+        gsonVTypeBuilder.build();
+        assertNull(jsonObject.get("NegativeInfinity"));
+
+        gsonVTypeBuilder.addIgnoreNaNAndInfinity("PositiveInfinity", Double.POSITIVE_INFINITY);
+        gsonVTypeBuilder.build();
+        assertNull(jsonObject.get("PositiveInfinity"));
+    }
+}

--- a/epics-vtype/vtype-json/src/main/java/org/epics/vtype/json/JsonVTypeBuilder.java
+++ b/epics-vtype/vtype-json/src/main/java/org/epics/vtype/json/JsonVTypeBuilder.java
@@ -89,8 +89,8 @@ class JsonVTypeBuilder implements JsonObjectBuilder {
         return this;
     }
 
-    public JsonVTypeBuilder addIgnoreNaN(String string, double d) {
-        if (!Double.isNaN(d)) {
+    public JsonVTypeBuilder addIgnoreNaNAndInfinity(String string, double d) {
+        if (!Double.isNaN(d) && !Double.isInfinite(d)) {
             builder.add(string, d);
         }
         return this;
@@ -141,12 +141,12 @@ class JsonVTypeBuilder implements JsonObjectBuilder {
     
     public JsonVTypeBuilder addDisplay(Display display) {
         return add("display", new JsonVTypeBuilder()
-                .addIgnoreNaN("lowAlarm", display.getAlarmRange().getMinimum())
-                .addIgnoreNaN("highAlarm", display.getAlarmRange().getMaximum())
-                .addIgnoreNaN("lowDisplay", display.getDisplayRange().getMinimum())
-                .addIgnoreNaN("highDisplay", display.getDisplayRange().getMaximum())
-                .addIgnoreNaN("lowWarning", display.getWarningRange().getMinimum())
-                .addIgnoreNaN("highWarning", display.getWarningRange().getMaximum())
+                .addIgnoreNaNAndInfinity("lowAlarm", display.getAlarmRange().getMinimum())
+                .addIgnoreNaNAndInfinity("highAlarm", display.getAlarmRange().getMaximum())
+                .addIgnoreNaNAndInfinity("lowDisplay", display.getDisplayRange().getMinimum())
+                .addIgnoreNaNAndInfinity("highDisplay", display.getDisplayRange().getMaximum())
+                .addIgnoreNaNAndInfinity("lowWarning", display.getWarningRange().getMinimum())
+                .addIgnoreNaNAndInfinity("highWarning", display.getWarningRange().getMaximum())
                 .add("units", display.getUnit())
                 .addNullableObject("description", display.getDescription()));
     }

--- a/epics-vtype/vtype-json/src/test/java/org/epics/vtype/json/JsonVTypeBuilderTest.java
+++ b/epics-vtype/vtype-json/src/test/java/org/epics/vtype/json/JsonVTypeBuilderTest.java
@@ -1,0 +1,35 @@
+package org.epics.vtype.json;
+
+import org.junit.Test;
+
+import javax.json.JsonObject;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class JsonVTypeBuilderTest {
+
+    @Test
+    public void testAddIgnoreNanAndInfinity(){
+        JsonVTypeBuilder jsonVTypeBuilder = new JsonVTypeBuilder();
+        jsonVTypeBuilder.addIgnoreNaNAndInfinity("thisIsOk", 7.7);
+        JsonObject jsonObject = jsonVTypeBuilder.build();
+        assertNotNull(jsonObject.get("thisIsOk"));
+
+        jsonVTypeBuilder.addIgnoreNaNAndInfinity("thisIsOkToo", 42);
+        jsonObject = jsonVTypeBuilder.build();
+        assertNotNull(jsonObject.get("thisIsOkToo"));
+
+        jsonVTypeBuilder.addIgnoreNaNAndInfinity("NaN", Double.NaN);
+        jsonObject =  jsonVTypeBuilder.build();
+        assertNull(jsonObject.get("NaN"));
+
+        jsonVTypeBuilder.addIgnoreNaNAndInfinity("NegativeInfinity", Double.NEGATIVE_INFINITY);
+        jsonObject = jsonVTypeBuilder.build();
+        assertNull(jsonObject.get("NegativeInfinity"));
+
+        jsonVTypeBuilder.addIgnoreNaNAndInfinity("PositiveInfinity", Double.POSITIVE_INFINITY);
+        jsonObject = jsonVTypeBuilder.build();
+        assertNull(jsonObject.get("PositiveInfinity"));
+    }
+}


### PR DESCRIPTION
If a PV specifies alarm limit range NaN - 42, then this may be converted to -Infinity - 42 by clients (e.g. CS Studio). Later, when converting this to JSON an exception will be thrown as -Infinity cannot be parsed as a number.

This PR adds a condition to skip conversion of Infinity on top of skipping NaN.