### PR TITLE
Fix for corner case in serialization of VTable

### DIFF
--- a/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/VTypeToGson.java
+++ b/epics-vtype/vtype-gson/src/main/java/org/epics/vtype/gson/VTypeToGson.java
@@ -280,49 +280,49 @@ public class VTypeToGson {
             listString.add(i, columnNames.get(i).getAsString());
             Class<?> clazz = getClass(columnTypes.get(i).getAsString());
             listClass.add(i, clazz);
-            JsonArray value = jsonObject.get("value").getAsJsonArray();
-            JsonArray ja = value.get(i).getAsJsonArray();
+            JsonArray value = jsonObject.get("value").getAsJsonArray()
+                    .get(i).getAsJsonArray();
             clazz = listClass.get(i);
-            if (ja == null || ja.size() == 0 || clazz == null) {
+            if (clazz == null) {
                 listObject.add(i, Collections.emptyList());
             } else {
                 String columnType = columnTypes.get(i).getAsString();
                 switch (columnType){
                     case "bool":
-                        listObject.add(i, GsonArrays.toListBoolean(ja));
+                        listObject.add(i, GsonArrays.toListBoolean(value));
                         break;
                     case "byte":
-                        listObject.add(i, GsonArrays.toListByte(ja));
+                        listObject.add(i, GsonArrays.toListByte(value));
                         break;
                     case "ubyte":
-                        listObject.add(i, GsonArrays.toListUByte(ja));
+                        listObject.add(i, GsonArrays.toListUByte(value));
                         break;
                     case "short":
-                        listObject.add(i, GsonArrays.toListShort(ja));
+                        listObject.add(i, GsonArrays.toListShort(value));
                         break;
                     case "ushort":
-                        listObject.add(i, GsonArrays.toListUShort(ja));
+                        listObject.add(i, GsonArrays.toListUShort(value));
                         break;
                     case "int":
-                        listObject.add(i, GsonArrays.toListInt(ja));
+                        listObject.add(i, GsonArrays.toListInt(value));
                         break;
                     case "uint":
-                        listObject.add(i, GsonArrays.toListUInteger(ja));
+                        listObject.add(i, GsonArrays.toListUInteger(value));
                         break;
                     case "long":
-                        listObject.add(i, GsonArrays.toListLong(ja));
+                        listObject.add(i, GsonArrays.toListLong(value));
                         break;
                     case "ulong":
-                        listObject.add(i, GsonArrays.toListULong(ja));
+                        listObject.add(i, GsonArrays.toListULong(value));
                         break;
                     case "float":
-                        listObject.add(i, GsonArrays.toListFloat(ja));
+                        listObject.add(i, GsonArrays.toListFloat(value));
                         break;
                     case "double":
-                        listObject.add(i, GsonArrays.toListDouble(ja));
+                        listObject.add(i, GsonArrays.toListDouble(value));
                         break;
                     case "string":
-                        listObject.add(i, GsonArrays.toListString(ja));
+                        listObject.add(i, GsonArrays.toListString(value));
                         break;
                     default:
                         listObject.add(i, Collections.emptyList());

--- a/epics-vtype/vtype-gson/src/test/java/org/epics/vtype/gson/VTypeToGsonTest.java
+++ b/epics-vtype/vtype-gson/src/test/java/org/epics/vtype/gson/VTypeToGsonTest.java
@@ -378,8 +378,9 @@ public class VTypeToGsonTest {
                 Long.TYPE,
                 Double.TYPE,
                 Float.TYPE,
-                String.class);
-        List<String> names = Arrays.asList("bool", "byte", "ubyte", "short", "ushort", "int", "uint", "long", "ulong", "double", "float", "string");
+                String.class,
+                Long.TYPE);
+        List<String> names = Arrays.asList("bool", "byte", "ubyte", "short", "ushort", "int", "uint", "long", "ulong", "double", "float", "string", "empty");
         boolean[] bools = {true, false, true};
         ArrayBoolean boolValues = ArrayBoolean.of(bools);
 
@@ -412,6 +413,9 @@ public class VTypeToGsonTest {
         String[] strings = {"a","b"};
         List<String> stringValues = Arrays.asList(strings);
 
+        long[] emptyLongs = new long[0];
+        ArrayLong emptyLongValues = ArrayLong.of(emptyLongs);
+
         VTable vTable = VTable.of(types, names, Arrays.asList(
                 boolValues,
                 byteValues,
@@ -424,11 +428,11 @@ public class VTypeToGsonTest {
                 ulongValues,
                 doubleValues,
                 floatValues,
-                stringValues));
+                stringValues,
+                emptyLongValues));
 
         // This should not fail
         JsonObject jsonObject = VTypeToGson.toJson(vTable);
-        System.out.println(jsonObject.toString());
 
         VTable deserialized = (VTable) VTypeToGson.toVType(jsonObject);
         assertEquals(vTable.getColumnCount(), deserialized.getColumnCount());
@@ -500,5 +504,10 @@ public class VTypeToGsonTest {
         String[] deserializedStrings = new String[deserializedStringValues.size()];
         deserializedStringValues.toArray(deserializedStrings);
         assertArrayEquals(strings, deserializedStrings);
+
+        ArrayLong deserializedEmptyLongValues = (ArrayLong)deserialized.getColumnData(12);
+        long[] deserializedEmptyLongs = new long[deserializedEmptyLongValues.size()];
+        deserializedEmptyLongValues.toArray(deserializedEmptyLongs);
+        assertArrayEquals(emptyLongs, deserializedEmptyLongs);
     }
 }

--- a/epics-vtype/vtype-json/src/main/java/org/epics/vtype/json/VTypeToJsonV1.java
+++ b/epics-vtype/vtype-json/src/main/java/org/epics/vtype/json/VTypeToJsonV1.java
@@ -384,49 +384,49 @@ class VTypeToJsonV1 {
             listString.add(i, columnNames.getString(i));
             Class<?> clazz = getClass(columnTypes.getString(i));
             listClass.add(i, clazz);
-            JsonArray value = jsonObject.getJsonArray("value");
-            JsonArray ja = value.getJsonArray(i);
+            JsonArray value = jsonObject.getJsonArray("value").getJsonArray(i);
             clazz = listClass.get(i);
-            if (ja == null || ja.isEmpty() || clazz == null) {
+            if (clazz == null) {
                 listObject.add(i, Collections.emptyList());
-            } else {
+            }
+            else {
                 String columnType = columnTypes.getString(i);
                 switch (columnType){
                     case "bool":
-                        listObject.add(i, JsonArrays.toListBoolean(ja));
+                        listObject.add(i, JsonArrays.toListBoolean(value));
                         break;
                     case "byte":
-                        listObject.add(i, JsonArrays.toListByte(ja));
+                        listObject.add(i, JsonArrays.toListByte(value));
                         break;
                     case "ubyte":
-                        listObject.add(i, JsonArrays.toListUByte(ja));
+                        listObject.add(i, JsonArrays.toListUByte(value));
                         break;
                     case "short":
-                        listObject.add(i, JsonArrays.toListShort(ja));
+                        listObject.add(i, JsonArrays.toListShort(value));
                         break;
                     case "ushort":
-                        listObject.add(i, JsonArrays.toListUShort(ja));
+                        listObject.add(i, JsonArrays.toListUShort(value));
                         break;
                     case "int":
-                        listObject.add(i, JsonArrays.toListInt(ja));
+                        listObject.add(i, JsonArrays.toListInt(value));
                         break;
                     case "uint":
-                        listObject.add(i, JsonArrays.toListUInteger(ja));
+                        listObject.add(i, JsonArrays.toListUInteger(value));
                         break;
                     case "long":
-                        listObject.add(i, JsonArrays.toListLong(ja));
+                        listObject.add(i, JsonArrays.toListLong(value));
                         break;
                     case "ulong":
-                        listObject.add(i, JsonArrays.toListULong(ja));
+                        listObject.add(i, JsonArrays.toListULong(value));
                         break;
                     case "float":
-                        listObject.add(i, JsonArrays.toListFloat(ja));
+                        listObject.add(i, JsonArrays.toListFloat(value));
                         break;
                     case "double":
-                        listObject.add(i, JsonArrays.toListDouble(ja));
+                        listObject.add(i, JsonArrays.toListDouble(value));
                         break;
                     case "string":
-                        listObject.add(i, JsonArrays.toListString(ja));
+                        listObject.add(i, JsonArrays.toListString(value));
                         break;
                     default:
                         listObject.add(i, Collections.emptyList());

--- a/epics-vtype/vtype-json/src/test/java/org/epics/vtype/json/VTypeToJsonTest.java
+++ b/epics-vtype/vtype-json/src/test/java/org/epics/vtype/json/VTypeToJsonTest.java
@@ -365,8 +365,9 @@ public class VTypeToJsonTest {
                 Long.TYPE,
                 Double.TYPE,
                 Float.TYPE,
-                String.class);
-        List<String> names = Arrays.asList("bool", "byte", "ubyte", "short", "ushort", "int", "uint", "long", "ulong", "double", "float", "string");
+                String.class,
+                Long.TYPE);
+        List<String> names = Arrays.asList("bool", "byte", "ubyte", "short", "ushort", "int", "uint", "long", "ulong", "double", "float", "string", "empty");
         boolean[] bools = {true, false, true};
         ArrayBoolean boolValues = ArrayBoolean.of(bools);
 
@@ -399,6 +400,9 @@ public class VTypeToJsonTest {
         String[] strings = {"a","b"};
         List<String> stringValues = Arrays.asList(strings);
 
+        long[] emptyLongs = new long[0];
+        ArrayLong emptyLongValues = ArrayLong.of(emptyLongs);
+
         VTable vTable = VTable.of(types, names, Arrays.asList(
                 boolValues,
                 byteValues,
@@ -411,11 +415,11 @@ public class VTypeToJsonTest {
                 ulongValues,
                 doubleValues,
                 floatValues,
-                stringValues));
+                stringValues,
+                emptyLongValues));
 
         // This should not fail
         JsonObject jsonObject = VTypeToJson.toJson(vTable);
-        System.out.println(jsonObject.toString());
 
         VTable deserialized = (VTable) VTypeToJson.toVType(jsonObject);
         assertEquals(vTable.getColumnCount(), deserialized.getColumnCount());
@@ -487,5 +491,10 @@ public class VTypeToJsonTest {
         String[] deserializedStrings = new String[deserializedStringValues.size()];
         deserializedStringValues.toArray(deserializedStrings);
         assertArrayEquals(strings, deserializedStrings);
+
+        ArrayLong deserializedEmptyLongValues = (ArrayLong)deserialized.getColumnData(12);
+        long[] deserializedEmptyLongs = new long[deserializedEmptyLongValues.size()];
+        deserializedEmptyLongValues.toArray(deserializedEmptyLongs);
+        assertArrayEquals(emptyLongs, deserializedEmptyLongs);
     }
 }


### PR DESCRIPTION
Corner case being a VTable where data arrays are empty.