### PR TITLE
Fix gpclient for structure fields.

### DIFF
--- a/gpclient/gpclient-pva/src/main/java/org/epics/gpclient/datasource/pva/PVAChannelHandler.java
+++ b/gpclient/gpclient-pva/src/main/java/org/epics/gpclient/datasource/pva/PVAChannelHandler.java
@@ -83,7 +83,7 @@ class PVAChannelHandler extends
 	private static PVStructure allPVRequest = createRequest.createRequest("field()");
 	private static PVStructure standardPutPVRequest = createRequest.createRequest("field(value)");
 	private static PVStructure enumPutPVRequest = createRequest.createRequest("field(value.index)");
-	
+               
 	private static final String PVREQUEST_PREFIX = "?request=";
 	private final PVStructure pvRequest;
 	private final String extractPVField;

--- a/gpclient/gpclient-pva/src/main/java/org/epics/gpclient/datasource/pva/PVATypeAdapter.java
+++ b/gpclient/gpclient-pva/src/main/java/org/epics/gpclient/datasource/pva/PVATypeAdapter.java
@@ -129,7 +129,7 @@ abstract class PVATypeAdapter implements DataSourceTypeAdapter<PVAConnectionPayl
         			break;
         		}
         	
-        	if (!match)
+        	if ((!match) && (!ntId.equalsIgnoreCase("structure")))
         		return false;
         }
         
@@ -139,8 +139,14 @@ abstract class PVATypeAdapter implements DataSourceTypeAdapter<PVAConnectionPayl
         	boolean match = false;
         	// we assume Structure here
         	Field channelType = connection.channelType;
-        	Field channelValueType = (channelType.getType() == Type.structure) ?
-        			((Structure)channelType).getField("value") : channelType;
+                Field channelValueType = null;                
+                if (null != connection.extractFieldName) {
+                    channelValueType = ((Structure)channelType).findSubField(connection.extractFieldName, ((Structure)channelType));                   
+                } else {
+                    channelValueType = (channelType.getType() == Type.structure) ?
+        			((Structure)channelType).getField("value") : channelType;                    
+                }
+                
         	if (channelValueType != null)
     		{
             	for (Field vf : valueFieldTypes)
@@ -172,9 +178,11 @@ abstract class PVATypeAdapter implements DataSourceTypeAdapter<PVAConnectionPayl
     	String extractFieldName = connection.extractFieldName;
     	if (extractFieldName != null)
     	{
-    		if (connection.channelType.getType() == Type.structure)
-    			message = message.getStructureField(extractFieldName);
-    		else
+    		if (connection.channelType.getType() == Type.structure) {
+                    if (null != message.getStructureField(extractFieldName)) 
+                        message = message.getStructureField(extractFieldName);
+                    else valueField = message.getSubField(extractFieldName); 
+                } else
     			// this avoids problem when scalars/scalar arrays needs to be passed as PVStructure message
     			valueField = message.getSubField(extractFieldName);
   

--- a/pvDataJava/src/org/epics/pvdata/factory/BaseStructure.java
+++ b/pvDataJava/src/org/epics/pvdata/factory/BaseStructure.java
@@ -192,6 +192,35 @@ public class BaseStructure extends BaseField implements Structure {
     public Field[] getFields() {
         return fields;
     }
+    
+    @Override
+    public Field findSubField(String fieldName, Structure pvStructure) {
+        if(fieldName==null || fieldName.length()<1) return null;
+        int index = fieldName.indexOf('.');
+        String name = fieldName;
+        String restOfName = null;
+        if(index>0) {
+            name = fieldName.substring(0, index);
+            if(fieldName.length()>index) {
+                restOfName = fieldName.substring(index+1);
+            }
+        }
+        Field[] pvFields = pvStructure.getFields();
+        String[] fieldNames = pvStructure.getFieldNames();
+        Field pvField = null;
+        for(int i=0; i < pvFields.length; i++) {
+            if(fieldNames[i].equals(name)) {
+                pvField = pvFields[i];
+                break;
+            }
+        }
+        if(pvField==null) return null;
+        if(restOfName==null) return pvField;
+        if(pvField.getType()!=Type.structure) return null;
+        return findSubField(restOfName,(Structure) pvField);
+    }         
+    
+    
     /* (non-Javadoc)
      * @see org.epics.pvdata.factory.BaseField#toString(java.lang.StringBuilder, int)
      */

--- a/pvDataJava/src/org/epics/pvdata/pv/Structure.java
+++ b/pvDataJava/src/org/epics/pvdata/pv/Structure.java
@@ -78,4 +78,13 @@ public interface Structure extends Field{
      * @return the name of the field
      */
     String getFieldName(int fieldIndex);
+    
+    /**
+     * Get the index of the specified field.
+     * 
+     * @param fieldName the name of the field
+     * @param pvStructure a structure instance to lookup the field
+     * @return  the field with fieldName
+     */
+    public Field findSubField(String fieldName, Structure pvStructure);      
 }

--- a/pvDataJava/test/org/epics/pvdata/FindSubFieldTest.java
+++ b/pvDataJava/test/org/epics/pvdata/FindSubFieldTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright information and license terms for this software can be
+ * found in the file LICENSE that is included with the distribution
+ */
+package org.epics.pvdata;
+
+import static junit.framework.TestCase.assertTrue;
+import org.epics.pvdata.factory.BaseScalar;
+import org.epics.pvdata.factory.BaseStructure;
+import org.epics.pvdata.pv.Field;
+import org.epics.pvdata.pv.ScalarType;
+import org.epics.pvdata.pv.Structure;
+import org.epics.pvdata.pv.Type;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author cgarcia
+ */
+public class FindSubFieldTest {
+    
+    public FindSubFieldTest() {
+    }
+    
+    @BeforeClass
+    public static void setUpClass() {
+    }
+    
+    @AfterClass
+    public static void tearDownClass() {
+    }
+    
+    @Before
+    public void setUp() {
+    }
+    
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void allScalar() {
+        Structure struct = CreateTestStructure.allScalar();
+
+        System.out.println("Structura: " + struct.toString());
+        BaseStructure bst = new BaseStructure(struct.getFieldNames(), struct.getFields());
+        Field field =  bst.findSubField("booleanValue", struct);
+        assertTrue(((BaseScalar) field).getScalarType() == ScalarType.pvBoolean);
+        field =  bst.findSubField("byteValue", struct);
+        assertTrue(((BaseScalar) field).getScalarType() == ScalarType.pvByte);                
+        field =  bst.findSubField("shortValue", struct);        
+        assertTrue(((BaseScalar) field).getScalarType() == ScalarType.pvShort);         
+        field =  bst.findSubField("intValue", struct);
+        assertTrue(((BaseScalar) field).getScalarType() == ScalarType.pvInt);         
+        field =  bst.findSubField("longValue", struct);   
+        assertTrue(((BaseScalar) field).getScalarType() == ScalarType.pvLong);         
+        field =  bst.findSubField("ubyteValue", struct);
+        assertTrue(((BaseScalar) field).getScalarType() == ScalarType.pvUByte);         
+        field =  bst.findSubField("ushortValue", struct);
+        assertTrue(((BaseScalar) field).getScalarType() == ScalarType.pvUShort);         
+        field =  bst.findSubField("uintValue", struct);
+        assertTrue(((BaseScalar) field).getScalarType() == ScalarType.pvUInt);         
+        field =  bst.findSubField("ulongValue", struct);
+        assertTrue(((BaseScalar) field).getScalarType() == ScalarType.pvULong);         
+        field =  bst.findSubField("floatValue", struct);
+        assertTrue(((BaseScalar) field).getScalarType() == ScalarType.pvFloat);         
+        field =  bst.findSubField("doubleValue", struct);
+        assertTrue(((BaseScalar) field).getScalarType() == ScalarType.pvDouble);         
+        field =  bst.findSubField("stringValue", struct);
+        assertTrue(((BaseScalar) field).getScalarType() == ScalarType.pvString);         
+
+        System.out.println("Campo: " + field.toString());
+
+    }
+}


### PR DESCRIPTION
This PR corrects the reading process for complex data structures.

It enables the execution of the following requests against a structure:

**_Future<VType> value = GPClient.readOnce("pva://demo.all?request=field(temperature)");_** 

**_Future<VType> value = GPClient.readOnce("pva://training:PID?request=field(alarm.severity)");_**

Regarding the writing process, we encountered some inconsistencies in the responses from the Python "p4p" server compared to the C++ servers; we consider this a topic for a separate PR, should it be required.

This pull request introduces support for recursively finding subfields within a `Structure` by field name, including nested fields, and integrates this functionality into the PVA type adapter logic. It also adds comprehensive unit tests to verify the new behavior.

### Core Functionality Additions

* Added a new method `findSubField(String fieldName, Structure pvStructure)` to the `Structure` interface and implemented it in `BaseStructure`, enabling recursive lookup of nested fields by dot-separated names [[1]](diffhunk://#diff-46b516e154dc290e9b6e8edb003134650cdabd54720236e8caa55c0e8f82805eR81-R89) [[2]](diffhunk://#diff-4db24d5719fb66c2920c541d4839333381e11c26b6410e730d25b73d8cba6d5cR195-R223).
* Updated the logic in `PVATypeAdapter.match` and `updateCache` to use `findSubField` when an `extractFieldName` is provided, improving support for extracting and matching nested fields in PVA structures [[1]](diffhunk://#diff-4c3abe46e6a4253a4044b3c86e7f4d1b7bee4c9a4f459479cb9e1f90517fd23fL142-R149) [[2]](diffhunk://#diff-4c3abe46e6a4253a4044b3c86e7f4d1b7bee4c9a4f459479cb9e1f90517fd23fL132-R132) [[3]](diffhunk://#diff-4c3abe46e6a4253a4044b3c86e7f4d1b7bee4c9a4f459479cb9e1f90517fd23fL175-R185).

### Testing

* Added a new test class `FindSubFieldTest.java` to verify that `findSubField` correctly locates scalar fields in a test structure, covering all scalar types.

These changes improve the flexibility and correctness of field extraction in PVA data sources, especially when dealing with nested structures.